### PR TITLE
Data table reload

### DIFF
--- a/ephemeris/shed_install.py
+++ b/ephemeris/shed_install.py
@@ -441,6 +441,7 @@ def run_data_managers(options):
         for dm in dms:
             dm_counter += 1
             dm_tool = dm.get('id')
+            data_tables = dm.get('data_tables', [])
             # Initate tool installation
             start = dt.datetime.now()
             log.debug('[dbkey {0}/{1}; DM: {2}/{3}] Installing dbkey {4} with '
@@ -471,6 +472,7 @@ def run_data_managers(options):
                                 errored_dms.append({'dbkey': dbkey_name, 'DM': dm_tool})
                         log.debug("", extra={'same_line': True})
                         time.sleep(10)
+                    reload_data_tables(gi, data_tables)
                     log.debug("\tDbkey '{0}' installed successfully in '{1}'".format(
                               dbkey.get('dbkey'), dt.datetime.now() - start))
             except ConnectionError as e:
@@ -482,6 +484,9 @@ def run_data_managers(options):
     log.info("All dbkeys & DMs listed in '{0}' have been processed.".format(dbkeys_list_file))
     log.info("Errored DMs: {0}".format(errored_dms))
     log.info("Total run time: {0}".format(dt.datetime.now() - istart))
+
+def reload_data_tables(gi, data_tables):
+    [gi.tool_data.reload_data_table(data_table) for data_table in data_tables]
 
 
 def install_repository_revision(tool, tsc):

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,3 @@
 six>=1.9.0
 pyyaml
-bioblend>=0.8.0
+bioblend>=0.8.1


### PR DESCRIPTION
Reload the data table after a data manager tool has run,
so that you can chain e.g downloading a reference fasta with creating the corresponding index.
Depends on https://github.com/galaxyproject/bioblend/pull/196 and a new bioblend release, I guess.