### PR TITLE
Be more generic in determining a server time-out

### DIFF
--- a/ephemeris/shed_install.py
+++ b/ephemeris/shed_install.py
@@ -631,7 +631,7 @@ class InstallToolManager(object):
                         log.debug("\tTool %s already installed (at revision %s)" %
                                   (tool['name'], tool['changeset_revision']))
                     else:
-                        if e.message == "Unexpected response from galaxy: 504":
+                        if "504" in e.message:
                             log.debug("Timeout during install of %s, extending wait to 1h", tool['name'])
                             success = wait_for_install(tool=tool, tsc=self.tsc, timeout=3600)
                             if success:


### PR DESCRIPTION
When Galaxy is setup behind a proxy, the reported message is different than the Galaxy-default so be much more permissive in determining when a tool installation is taking a while.