### PR TITLE
enable global options in a tool yaml file

### DIFF
--- a/ephemeris/shed_install.py
+++ b/ephemeris/shed_install.py
@@ -47,7 +47,7 @@ from bioblend.toolshed import ToolShedInstance
 MTS = 'https://toolshed.g2.bx.psu.edu/'  # Main Tool Shed
 
 # The behavior of a tool installation and its dependencies can be controlled in a few ways.
-# You can add 
+# You can add
 #   - install_tool_dependencies: True or False
 #   - install_repository_dependencies: True or False
 #   - install_resolver_dependencies: True or False

--- a/ephemeris/shed_install.py
+++ b/ephemeris/shed_install.py
@@ -591,9 +591,9 @@ class InstallToolManager(object):
     def __init__(self,
                  tools_info,
                  gi,
-                 default_install_tool_dependencies=False,
-                 default_install_resolver_dependencies=True,
-                 default_install_repository_dependencies=False,
+                 default_install_tool_dependencies=INSTALL_TOOL_DEPENDENCIES,
+                 default_install_resolver_dependencies=INSTALL_RESOLVER_DEPENDENCIES,
+                 default_install_repository_dependencies=INSTALL_REPOSITORY_DEPENDENCIES,
                  require_tool_panel_info=True):
         self.tools_info = tools_info
         self.gi = gi

--- a/ephemeris/shed_install.py
+++ b/ephemeris/shed_install.py
@@ -43,7 +43,18 @@ from bioblend.galaxy.client import ConnectionError
 from bioblend.galaxy.toolshed import ToolShedClient
 from bioblend.toolshed import ToolShedInstance
 
+# If no toolshed is specified for a tool/tool-suite, the Main Tool Shed is taken
 MTS = 'https://toolshed.g2.bx.psu.edu/'  # Main Tool Shed
+
+# The behavior of a tool installation and its dependencies can be controlled in a few ways.
+# You can add 
+#   - install_tool_dependencies: True or False
+#   - install_repository_dependencies: True or False
+#   - install_resolver_dependencies: True or False
+# to every tool section in the tool-yaml file or you can add these options to the top of the yaml
+# file (next to galaxy_instance or api_key) to set a global default value, which can be overwritten
+# later in every section. Not specifying any of these options will use the values below,
+# means traditional tool_dependencies will not be installed.
 INSTALL_TOOL_DEPENDENCIES = False
 INSTALL_REPOSITORY_DEPENDENCIES = True
 INSTALL_RESOLVER_DEPENDENCIES = True

--- a/ephemeris/shed_install.py
+++ b/ephemeris/shed_install.py
@@ -48,6 +48,7 @@ INSTALL_TOOL_DEPENDENCIES = False
 INSTALL_REPOSITORY_DEPENDENCIES = False
 INSTALL_RESOLVER_DEPENDENCIES = True
 
+
 class ProgressConsoleHandler(logging.StreamHandler):
     """
     A handler class which allows the cursor to stay on
@@ -547,7 +548,7 @@ def get_install_tool_manager(options):
     install_tool_dependencies = INSTALL_TOOL_DEPENDENCIES
     install_repository_dependencies = INSTALL_REPOSITORY_DEPENDENCIES
     install_resolver_dependencies = INSTALL_RESOLVER_DEPENDENCIES
-    
+
     tool_list_file = options.tool_list_file
     if tool_list_file:
         tl = load_input_file(tool_list_file)  # Input file contents

--- a/ephemeris/shed_install.py
+++ b/ephemeris/shed_install.py
@@ -45,7 +45,7 @@ from bioblend.toolshed import ToolShedInstance
 
 MTS = 'https://toolshed.g2.bx.psu.edu/'  # Main Tool Shed
 INSTALL_TOOL_DEPENDENCIES = False
-INSTALL_REPOSITORY_DEPENDENCIES = False
+INSTALL_REPOSITORY_DEPENDENCIES = True
 INSTALL_RESOLVER_DEPENDENCIES = True
 
 


### PR DESCRIPTION
This PR will enable global options in a tool yaml files. Means 
```
  install_repository_dependencies: true
  install_resolver_dependencies: true
  install_tool_dependencies: false
```
can be specified as top arguments next to the Galaxy instance and API key. It will also change the default setting, to install resolver-dependencies and not tool-dependencies anymore.
