### PR TITLE
Add sleep script

### DIFF
--- a/ephemeris/sleep.py
+++ b/ephemeris/sleep.py
@@ -1,0 +1,53 @@
+#!/usr/bin/env python
+import requests
+import sys
+import time
+
+from argparse import ArgumentParser
+
+from .common_parser import get_common_args
+from .shed_install import setup_global_logger, _disable_external_library_logging
+
+
+def _parse_cli_options():
+    """
+    Parse command line options, returning `parse_args` from `ArgumentParser`.
+    """
+    parent = get_common_args(login_required=False)
+    parser = ArgumentParser(parents=[parent], usage="usage: python %(prog)s <options>")
+    parser.add_argument("--timeout",
+                        default=0, type=int,
+                        help="Galaxy startup timeout. The default value of 0 waits forever")
+    return parser.parse_args()
+
+
+def main():
+    global log
+    _disable_external_library_logging()
+    log = setup_global_logger(include_file=True)
+    options = _parse_cli_options()
+
+    count = 0
+    while True:
+        try:
+            result = requests.get(options.galaxy + '/api/version').json()
+            if options.verbose:
+                sys.stdout.write("Galaxy Version: %s\n" % result['version_major'])
+            break
+        except requests.exceptions.ConnectionError as e:
+            if options.verbose:
+                sys.stdout.write("[%02d] Galaxy not up yet... %s\n" % (count, str(e)[0:100]))
+                sys.stdout.flush()
+        count += 1
+
+        # If we cannot talk to galaxy and are over the timeout
+        if options.timeout != 0 and count > options.timeout:
+            sys.stderr.write("Failed to contact Galaxy\n")
+            sys.exit(1)
+
+        time.sleep(1)
+    sys.exit(0)
+
+
+if __name__ == "__main__":
+    main()

--- a/ephemeris/sleep.py
+++ b/ephemeris/sleep.py
@@ -1,12 +1,12 @@
 #!/usr/bin/env python
-import requests
 import sys
 import time
 
 from argparse import ArgumentParser
 
+import requests
+
 from .common_parser import get_common_args
-from .shed_install import setup_global_logger, _disable_external_library_logging
 
 
 def _parse_cli_options():
@@ -14,17 +14,18 @@ def _parse_cli_options():
     Parse command line options, returning `parse_args` from `ArgumentParser`.
     """
     parent = get_common_args(login_required=False)
-    parser = ArgumentParser(parents=[parent], usage="usage: python %(prog)s <options>")
+    parser = ArgumentParser(parents=[parent], usage="usage: python %(prog)s <options>",
+                            description="Script to sleep and wait for Galaxy to be alive.")
     parser.add_argument("--timeout",
                         default=0, type=int,
-                        help="Galaxy startup timeout. The default value of 0 waits forever")
+                        help="Galaxy startup timeout in seconds. The default value of 0 waits forever")
     return parser.parse_args()
 
 
 def main():
-    global log
-    _disable_external_library_logging()
-    log = setup_global_logger(include_file=True)
+    """
+    Main function
+    """
     options = _parse_cli_options()
 
     count = 0

--- a/setup.py
+++ b/setup.py
@@ -41,6 +41,7 @@ ENTRY_POINTS = '''
         run-data-managers=ephemeris.run_data_managers:main
         workflow-to-tools=ephemeris.generate_tool_list_from_ga_workflow_files:main
         setup-data-libraries=ephemeris.setup_data_libraries:main
+        galaxy-sleep=ephemeris.sleep:main
 '''
 PACKAGE_DATA = {
     # Be sure to update MANIFEST.in for source dist.

--- a/setup.py
+++ b/setup.py
@@ -41,7 +41,7 @@ ENTRY_POINTS = '''
         run-data-managers=ephemeris.run_data_managers:main
         workflow-to-tools=ephemeris.generate_tool_list_from_ga_workflow_files:main
         setup-data-libraries=ephemeris.setup_data_libraries:main
-        galaxy-sleep=ephemeris.sleep:main
+        galaxy-wait=ephemeris.sleep:main
 '''
 PACKAGE_DATA = {
     # Be sure to update MANIFEST.in for source dist.


### PR DESCRIPTION
Lots of the flavour images do a `startup_lite && sleep 30 && ...` in order to do things on a live database. This number can be quite variable. 30s was fine for me, but wasn't for a colleague who had to increase it.

This script can be used in place of `sleep 30` and will sleep until `/api/version` is available. This *should* be much more reliable.

A timeout option is provided to prevent abusing build resources if something else is at fault (e.g. a missing package allowed startup_lite to succeed initially but fail silently later).