### PR TITLE
Enable api key on run_data_managers

### DIFF
--- a/ephemeris/run_data_managers.py
+++ b/ephemeris/run_data_managers.py
@@ -33,12 +33,15 @@ def wait(gi, job):
 
 def run_dm(args):
     url = args.galaxy or DEFAULT_URL
-    if args.api_key != "":
+    if args.api_key:
         gi = GalaxyInstance(url=url, key=args.api_key)
     else:
         gi = GalaxyInstance(url=url, email=args.user, password=args.password)
-        # should test valid connection
-        log.info("List of valid histories: %s" % gi.users.get_current_user())
+    
+    # should test valid connection
+    # The following should throw a ConnectionError when invalid API key or password
+    genomes = gi.genomes.get_genomes()
+      
 
     conf = yaml.load(open(args.config))
     for dm in conf.get('data_managers'):

--- a/ephemeris/run_data_managers.py
+++ b/ephemeris/run_data_managers.py
@@ -37,11 +37,10 @@ def run_dm(args):
         gi = GalaxyInstance(url=url, key=args.api_key)
     else:
         gi = GalaxyInstance(url=url, email=args.user, password=args.password)
-    
     # should test valid connection
     # The following should throw a ConnectionError when invalid API key or password
     genomes = gi.genomes.get_genomes()
-      
+    log.info('Number of installed genomes: %s' % str(len(genomes)) )
 
     conf = yaml.load(open(args.config))
     for dm in conf.get('data_managers'):

--- a/ephemeris/run_data_managers.py
+++ b/ephemeris/run_data_managers.py
@@ -40,7 +40,7 @@ def run_dm(args):
     # should test valid connection
     # The following should throw a ConnectionError when invalid API key or password
     genomes = gi.genomes.get_genomes()
-    log.info('Number of installed genomes: %s' % str(len(genomes)) )
+    log.info('Number of installed genomes: %s' % str(len(genomes)))
 
     conf = yaml.load(open(args.config))
     for dm in conf.get('data_managers'):

--- a/ephemeris/run_data_managers.py
+++ b/ephemeris/run_data_managers.py
@@ -33,10 +33,12 @@ def wait(gi, job):
 
 def run_dm(args):
     url = args.galaxy or DEFAULT_URL
-    gi = GalaxyInstance(url=url, email=args.user, password=args.password)
-
-    # should test valid connection
-    log.info("List of valid histories: %s" % gi.users.get_current_user())
+    if args.api_key != "":
+        gi = GalaxyInstance(url=url, key=args.api_key)
+    else:
+        gi = GalaxyInstance(url=url, email=args.user, password=args.password)
+        # should test valid connection
+        log.info("List of valid histories: %s" % gi.users.get_current_user())
 
     conf = yaml.load(open(args.config))
     for dm in conf.get('data_managers'):


### PR DESCRIPTION
run_data_managers has an -a or --api-key flag inherited from common args but did not allow for using the api_key.