### PR TITLE
fix error in run_data_managers

### DIFF
--- a/ephemeris/run_data_managers.py
+++ b/ephemeris/run_data_managers.py
@@ -59,7 +59,7 @@ def run_dm(args):
             for data_table in dm.get('data_table_reload', []):
                 # reload two times
                 for i in range(2):
-                    gi.make_get_request(urljoin(url, 'api/tool_data/%s/reload' % data_table))
+                    gi.make_get_request(urljoin(gi.url, 'api/tool_data/%s/reload' % data_table))
                     time.sleep(5)
 
 


### PR DESCRIPTION
Below error was generated when running run-data-managers. I suppose this was because the galaxy url was not properly prepended to the /api part. With this fix the problem seems to be solved.

> Traceback (most recent call last):
>   File "/usr/local/bin/run-data-managers", line 11, in <module>
>     sys.exit(main())
>   File "/usr/local/lib/python2.7/dist-packages/ephemeris/run_data_managers.py", line 80, in main
>     run_dm(args)
>   File "/usr/local/lib/python2.7/dist-packages/ephemeris/run_data_managers.py", line 62, in run_dm
>     gi.make_get_request(urljoin(url, 'api/tool_data/%s/reload' % data_table))
>   File "/usr/local/lib/python2.7/dist-packages/bioblend/galaxyclient.py", line 88, in make_get_request
>     r = requests.get(url, **kwargs)
>   File "/usr/local/lib/python2.7/dist-packages/requests/api.py", line 72, in get
>     return request('get', url, params=params, **kwargs)
>   File "/usr/local/lib/python2.7/dist-packages/requests/api.py", line 58, in request
>     return session.request(method=method, url=url, **kwargs)
>   File "/usr/local/lib/python2.7/dist-packages/requests/sessions.py", line 504, in request
>     prep = self.prepare_request(req)
>   File "/usr/local/lib/python2.7/dist-packages/requests/sessions.py", line 436, in prepare_request
>     hooks=merge_hooks(request.hooks, self.hooks),
>   File "/usr/local/lib/python2.7/dist-packages/requests/models.py", line 302, in prepare
>     self.prepare_url(url, params)
>   File "/usr/local/lib/python2.7/dist-packages/requests/models.py", line 382, in prepare_url
>     raise MissingSchema(error)
> requests.exceptions.MissingSchema: Invalid URL 'api/tool_data/all_fasta/reload': No schema supplied. Perhaps you meant http://api/tool_data/all_fasta/reload?

