### PR TITLE
Fixed empty items list issue

### DIFF
--- a/ephemeris/run_data_managers.py
+++ b/ephemeris/run_data_managers.py
@@ -40,7 +40,7 @@ def run_dm(args):
 
     conf = yaml.load(open(args.config))
     for dm in conf.get('data_managers'):
-        for item in dm.get('items', [None]):
+        for item in dm.get('items', ['']):
             dm_id = dm['id']
             params = dm['params']
             log.info('Running DM: %s' % dm_id)


### PR DESCRIPTION
Sometimes no items are needed for run-data-managers, see the following file:
```YAML
data_managers:
    - id: all_fasta_by_path_manager
      params:
        - 'dbkey': 'GRCh38/hg38'
        - 'name': 'Human Genome Assembly GRCh38/hg38'
        - 'path': '/export/genomes/hg38.fa'
      data_table_reload:
        - all_fasta
        - __dbkeys__
```

However, run-data-managers throws the following error when the file is run:
```
Traceback (most recent call last):
  File "/home/ruben/ephemeris/.venv/bin/run-data-managers", line 11, in <module>
    load_entry_point('ephemeris==0.6.2.dev0', 'console_scripts', 'run-data-managers')()
  File "/home/ruben/ephemeris/.venv/lib/python2.7/site-packages/ephemeris-0.6.2.dev0-py2.7.egg/ephemeris/run_data_managers.py", line 80, in main
    run_dm(args)
  File "/home/ruben/ephemeris/.venv/lib/python2.7/site-packages/ephemeris-0.6.2.dev0-py2.7.egg/ephemeris/run_data_managers.py", line 52, in run_dm
    value = re.sub(r'{{\s*item\s*}}', item, value, flags=re.IGNORECASE)
  File "/home/ruben/ephemeris/.venv/lib/python2.7/re.py", line 155, in sub
    return _compile(pattern, flags).sub(repl, string, count)
  File "/home/ruben/ephemeris/.venv/lib/python2.7/re.py", line 286, in _subx
    template = _compile_repl(template, pattern)
  File "/home/ruben/ephemeris/.venv/lib/python2.7/re.py", line 271, in _compile_repl
    p = sre_parse.parse_template(repl, pattern)
  File "/home/ruben/ephemeris/.venv/lib/python2.7/sre_parse.py", line 737, in parse_template
    s = Tokenizer(source)
  File "/home/ruben/ephemeris/.venv/lib/python2.7/sre_parse.py", line 192, in __init__
    self.__next()
  File "/home/ruben/ephemeris/.venv/lib/python2.7/sre_parse.py", line 194, in __next
    if self.index >= len(self.string):
TypeError: object of type 'NoneType' has no len()
```
The fix is to default items to empty string instead of None.