### PR TITLE
Allow advanced jinja templating

### DIFF
--- a/ephemeris/run_data_managers.py
+++ b/ephemeris/run_data_managers.py
@@ -40,15 +40,17 @@ def wait(gi, job):
         log.info('Data manager still running.')
         time.sleep(30)
 
-def parse_items(items,genomes):
+
+def parse_items(items, genomes):
     if bool(genomes):
-        items_template=Template(json.dumps(items))
+        items_template = Template(json.dumps(items))
         rendered_items = items_template.render(genomes=json.dumps(genomes))
-        #Remove trailing " if present
+        # Remove trailing " if present
         if rendered_items.startswith('"') and rendered_items.endswith('"'):
-           rendered_items = rendered_items[1:-1]
-        items=json.loads(rendered_items)
+            rendered_items = rendered_items[1:-1]
+        items = json.loads(rendered_items)
     return items
+
 
 def run_dm(args):
     url = args.galaxy or DEFAULT_URL
@@ -62,9 +64,9 @@ def run_dm(args):
     log.info('Number of installed genomes: %s' % str(len(genomes)))
 
     conf = yaml.load(open(args.config))
-    genomes=conf.get('genomes','')
+    genomes = conf.get('genomes', '')
     for dm in conf.get('data_managers'):
-        items=parse_items(dm.get('items', ['']),genomes)
+        items = parse_items(dm.get('items', ['']), genomes)
         for item in items:
             dm_id = dm['id']
             params = dm['params']

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,4 @@
 six>=1.9.0
 pyyaml
 bioblend>=0.8.0
+Jinja2

--- a/tests/run_data_managers.yaml.sample
+++ b/tests/run_data_managers.yaml.sample
@@ -21,11 +21,16 @@ data_managers:
 
 #    - id: toolshed.g2.bx.psu.edu/repos/devteam/data_manager_bowtie2_index_builder/bowtie2_index_builder_data_manager/2.2.6
 #      params:
-#        - 'all_fasta_source': '{{ item }}'
+#        - 'all_fasta_source': '{{ item.id }}'
+#        - 'sequence_name': '{{ item.name }}'
+#        - 'sequence_id': '{{ item.id }}'
 #      items:
-#        #- ce8
-#        - dm3
-#        #- mm9
+#        - id: ce8
+#          name: C. elegans (ce8)
+#        - id: dm3
+#          name: D. melanogaster Apr. 2006 (BDGP r5/dm3)
+#        - id: mm9
+#          name: M. musculus July 2007 (NCBI37/mm9)
 #      data_table_reload:
 #        # Bowtie creates indices for Bowtie and TopHat
 #        - bowtie2_indexes

--- a/tests/run_data_managers.yaml.sample.advanced
+++ b/tests/run_data_managers.yaml.sample.advanced
@@ -1,0 +1,36 @@
+# configuration for fetch and index genomes
+
+genomes:
+  - id: ce8
+    name: C. elegans (ce8)
+  - id: dm3
+    name: D. melanogaster Apr. 2006 (BDGP r5/dm3)
+  - id: mm9
+    name: M. musculus July 2007 (NCBI37/mm9)
+
+data_managers:
+    # Data manager ID
+    - id: toolshed.g2.bx.psu.edu/repos/devteam/data_manager_fetch_genome_dbkeys_all_fasta/data_manager_fetch_genome_all_fasta_dbkey/0.0.2
+      # tool parameters, nested parameters should be specified using a pipe (|)
+      params:
+        - 'dbkey_source|dbkey': '{{ item.id }}'
+        - 'reference_source|reference_source_selector': 'ucsc'
+        - 'reference_source|requested_dbkey': '{{ item.id }}'
+      # Items can be set to "{{ genomes }}" which removes a lot of copy paste clutter.
+      # Warning: this is not Ansible. Other values than "genomes" will not work!
+      items: "{{ genomes }}"
+      # Name of the data-tables you want to reload after your DM are finished. This can be important for subsequent data managers
+      data_table_reload:
+        - all_fasta
+        - __dbkeys__
+
+#    - id: toolshed.g2.bx.psu.edu/repos/devteam/data_manager_bowtie2_index_builder/bowtie2_index_builder_data_manager/2.2.6
+#      params:
+#        - 'all_fasta_source': '{{ item.id }}'
+#        - 'sequence_name': '{{ item.name }}'
+#        - 'sequence_id': '{{ item.id }}'
+#      items: "{{ genomes }}"
+#      data_table_reload:
+#        # Bowtie creates indices for Bowtie and TopHat
+#        - bowtie2_indexes
+#        - tophat2_indexes

--- a/tests/run_data_managers.yaml.sample.advanced
+++ b/tests/run_data_managers.yaml.sample.advanced
@@ -18,6 +18,9 @@ data_managers:
         - 'reference_source|requested_dbkey': '{{ item.id }}'
       # Items can be set to "{{ genomes }}" which removes a lot of copy paste clutter.
       # Warning: this is not Ansible. Other values than "genomes" will not work!
+      # If you want to go even more advanced:
+      # you could set up genomes as a dictionary, with keys having lists as values
+      # and call those lists as "{{ genomes.proteomes }}" or "{{ genomes.dna }}" for example.
       items: "{{ genomes }}"
       # Name of the data-tables you want to reload after your DM are finished. This can be important for subsequent data managers
       data_table_reload:


### PR DESCRIPTION
Swapped out the regex substitution for jinja2 templating.
This allows for more functional templating as shown in `tests/run_data_managers.yaml.sample`.
It is still compatible with the old format.
This is in the first two commits.

Since having more than 3 genomes already gives some intensive copy and paste clutter also a `genomes` variable is added. see `tests/run_data_managers.yaml.sample.advanced`.
This was added in the last two commits.

This will have merge conflicts with #51 , but I already fixed that in my own fork of ephemeris (in the `fixes` branch). So I can update as soon as #51 is merged.