### PR TITLE
Parallelization of run-data-managers. Add galaxy-wait to tests. Fix galaxy-wait issue with nginx.

### DIFF
--- a/ephemeris/run_data_managers.py
+++ b/ephemeris/run_data_managers.py
@@ -43,7 +43,7 @@ def wait(gi, job_list):
     """
     # Empty list returns false
     while bool(job_list):
-        finished_jobs=[]
+        finished_jobs = []
         for job in job_list:
             value = job['outputs']
             job_id = job['outputs'][0]['hid']
@@ -54,9 +54,10 @@ def wait(gi, job_list):
                 finished_jobs.append(job)
             else:
                 log.debug('Job %i still running.' % job_id)
-        # only sleep if job_list is not empty yet.
+        # Remove finished jobs from job_list.
         for finished_job in finished_jobs:
-            job_list.remove(finished_job) # Empties the list.
+            job_list.remove(finished_job)
+        # only sleep if job_list is not empty yet.
         if bool(job_list):
             time.sleep(30)
 

--- a/ephemeris/run_data_managers.py
+++ b/ephemeris/run_data_managers.py
@@ -167,7 +167,6 @@ def run_dm(args):
             if input_entries_exist_in_data_tables(tool_data_client, data_tables, inputs) and not args.overwrite:
                 log.info('%s already run for %s' % (dm_id, inputs))
             else:
-                log.info('Running DM: "%s" with parameters: %s' % (dm_id, inputs))
                 # run the DM-job
                 job = gi.tools.run_tool(history_id=None, tool_id=dm_id, tool_inputs=inputs)
                 log.info('Dispatched job %i. Running DM: "%s" with parameters: %s' % (job['outputs'][0]['hid'], dm_id, inputs))

--- a/ephemeris/run_data_managers.py
+++ b/ephemeris/run_data_managers.py
@@ -51,11 +51,12 @@ def wait(gi, job_list):
             state = gi.datasets.show_dataset(value[0]['id'])['state']
             if state in ['ok', 'error']:
                 log.info('Job %i finished with state %s.' % (job_id, state))
+                finished_jobs.append(job)
             else:
                 log.debug('Job %i still running.' % job_id)
         # only sleep if job_list is not empty yet.
         for finished_job in finished_jobs:
-            job_list.remove(job) # Empties the list.
+            job_list.remove(finished_job) # Empties the list.
         if bool(job_list):
             time.sleep(30)
 

--- a/ephemeris/run_data_managers.py
+++ b/ephemeris/run_data_managers.py
@@ -53,7 +53,9 @@ def wait(gi, job_list):
                 job_list.remove(job) # Empties the list.
             else:
                 log.info('Job %i still running.' % job_id)
-        time.sleep(30)
+        # only sleep if job_list is not empty yet.
+        if bool(job_list):
+           time.sleep(30)
 
 
 def data_table_entry_exists(tool_data_client, data_table_name, entry, column='value'):

--- a/ephemeris/run_data_managers.py
+++ b/ephemeris/run_data_managers.py
@@ -189,7 +189,8 @@ def main():
     args = parser.parse_args()
     if args.verbose:
         log.basicConfig(level=log.DEBUG)
-
+    else:
+        log.basicConfig(level=log.INFO)
     log.info("Running data managers...")
     run_dm(args)
 

--- a/ephemeris/run_data_managers.py
+++ b/ephemeris/run_data_managers.py
@@ -50,12 +50,12 @@ def wait(gi, job_list):
             state = gi.datasets.show_dataset(value[0]['id'])['state']
             if state in ['ok', 'error']:
                 log.info('Job %i finished with state %s.' % (job_id, state))
-                job_list.remove(job) # Empties the list.
+                job_list.remove(job)  # Empties the list.
             else:
                 log.info('Job %i still running.' % job_id)
         # only sleep if job_list is not empty yet.
         if bool(job_list):
-           time.sleep(30)
+            time.sleep(30)
 
 
 def data_table_entry_exists(tool_data_client, data_table_name, entry, column='value'):
@@ -165,11 +165,9 @@ def run_dm(args):
                 log.info('Running DM: "%s" with parameters: %s' % (dm_id, inputs))
                 # run the DM-job
                 job = gi.tools.run_tool(history_id=None, tool_id=dm_id, tool_inputs=inputs)
-                log.info('Dispatched job %i. Running DM: "%s" with parameters: %s' % (job['outputs'][0]['hid'],dm_id, inputs))
+                log.info('Dispatched job %i. Running DM: "%s" with parameters: %s' % (job['outputs'][0]['hid'], dm_id, inputs))
                 job_list.append(job)
         wait(gi, job_list)
-
-
 
 
 def _parser():

--- a/ephemeris/run_data_managers.py
+++ b/ephemeris/run_data_managers.py
@@ -45,7 +45,7 @@ def wait(gi, job_list):
     """
 
     failed_jobs = []
-    succesfull_jobs = []
+    successful_jobs = []
 
     # Empty list returns false and stops the loop.
     while bool(job_list):
@@ -57,7 +57,7 @@ def wait(gi, job_list):
             state = gi.datasets.show_dataset(value[0]['id'])['state']
             if state == 'ok':
                 log.info('Job %i finished with state %s.' % (job_id, state))
-                succesfull_jobs.append(job)
+                successful_jobs.append(job)
                 finished_jobs.append(job)
             if state == 'error':
                 log.error('Job %i finished with state %s.' % (job_id, state))
@@ -71,7 +71,7 @@ def wait(gi, job_list):
         # only sleep if job_list is not empty yet.
         if bool(job_list):
             time.sleep(30)
-    return succesfull_jobs, failed_jobs
+    return successful_jobs, failed_jobs
 
 
 def data_table_entry_exists(tool_data_client, data_table_name, entry, column='value'):
@@ -158,7 +158,7 @@ def run_dm(args):
 
     number_skipped_jobs = 0
     all_failed_jobs = []
-    all_successfull_jobs = []
+    all_successful_jobs = []
 
     conf = yaml.load(open(args.config))
     genomes = conf.get('genomes', '')
@@ -187,17 +187,17 @@ def run_dm(args):
                 job = gi.tools.run_tool(history_id=None, tool_id=dm_id, tool_inputs=inputs)
                 log.info('Dispatched job %i. Running DM: "%s" with parameters: %s' % (job['outputs'][0]['hid'], dm_id, inputs))
                 job_list.append(job)
-        succesfull_jobs, failed_jobs = wait(gi, job_list)
+        successful_jobs, failed_jobs = wait(gi, job_list)
         if failed_jobs:
             if not args.ignore_errors:
-                raise Exception('Not all jobs successfull! aborting...')
+                raise Exception('Not all jobs successful! aborting...')
                 break
             else:
-                log.error('Not all jobs successfull! ignoring...')
-        all_successfull_jobs += succesfull_jobs
+                log.error('Not all jobs successful! ignoring...')
+        all_successful_jobs += successful_jobs
         all_failed_jobs += failed_jobs
     job_summary = dict()
-    job_summary['succesfull_jobs'] = len(all_successfull_jobs)
+    job_summary['successful_jobs'] = len(all_successful_jobs)
     job_summary['failed_jobs'] = len(all_failed_jobs)
     job_summary['skipped_jobs'] = number_skipped_jobs
     return job_summary
@@ -229,7 +229,7 @@ def main():
     log.info("Running data managers...")
     job_summary = run_dm(args)
     log.info('Finished running data managers. Results:')
-    log.info('Succesfull jobs: %i ' % job_summary['succesfull_jobs'])
+    log.info('Successful jobs: %i ' % job_summary['successful_jobs'])
     log.info('Skipped jobs: %i ' % job_summary['skipped_jobs'])
     log.info('Failed jobs: %i ' % job_summary['failed_jobs'])
 

--- a/ephemeris/run_data_managers.py
+++ b/ephemeris/run_data_managers.py
@@ -1,11 +1,12 @@
 #!/usr/bin/env python
 '''Run-data-managers is a tool for provisioning data on a galaxy instance.
 
-Run-data-managers has the ability to reload the datatables after a data manager has finished.
-It is therefore able to run multiple data managers that are interdependent.
+Run-data-managers has the ability to run multiple data managers that are interdependent.
 When a reference genome is needed for bwa-mem for example, Run-data-managers
-can first run a data manager to fetch the fasta file, reload the data table and run
+can first run a data manager to fetch the fasta file and run
 another data manager that indexes the fasta file for bwa-mem.
+This functionality depends on the "watch_tool_data_dir" setting in galaxy.ini to be True.
+Also, if a new data manager is installed, galaxy needs to be restarted in order for it's tool_data_dir to be watched.
 
 Run-data-managers needs a yaml that specifies what data managers are run and with which settings.
 An example file can be found `here <https://github.com/galaxyproject/ephemeris/blob/master/tests/run_data_managers.yaml.sample>`_.

--- a/ephemeris/run_data_managers.py
+++ b/ephemeris/run_data_managers.py
@@ -43,10 +43,11 @@ def wait(gi, job_list):
         It will check the state of the created datasets every 30s.
         It will return a tuple: ( finished_jobs, failed_jobs )
     """
-    # Empty list returns false
+    finished_jobs = []
+    failed_jobs = []
+
+    # Empty list returns false and stops the loop.
     while bool(job_list):
-        finished_jobs = []
-        failed_jobs = []
         for job in job_list:
             value = job['outputs']
             job_id = job['outputs'][0]['hid']

--- a/ephemeris/run_data_managers.py
+++ b/ephemeris/run_data_managers.py
@@ -43,6 +43,7 @@ def wait(gi, job_list):
     """
     # Empty list returns false
     while bool(job_list):
+        finished_jobs=[]
         for job in job_list:
             value = job['outputs']
             job_id = job['outputs'][0]['hid']
@@ -50,10 +51,11 @@ def wait(gi, job_list):
             state = gi.datasets.show_dataset(value[0]['id'])['state']
             if state in ['ok', 'error']:
                 log.info('Job %i finished with state %s.' % (job_id, state))
-                job_list.remove(job)  # Empties the list.
             else:
-                log.info('Job %i still running.' % job_id)
+                log.debug('Job %i still running.' % job_id)
         # only sleep if job_list is not empty yet.
+        for finished_job in finished_jobs:
+            job_list.remove(job) # Empties the list.
         if bool(job_list):
             time.sleep(30)
 

--- a/ephemeris/run_data_managers.py
+++ b/ephemeris/run_data_managers.py
@@ -224,7 +224,7 @@ def main():
         log.basicConfig(level=log.INFO)
     log.info("Running data managers...")
     job_summary = run_dm(args)
-    log.info('\nFinished running data managers. Results:')
+    log.info('Finished running data managers. Results:')
     log.info('Succesfull jobs: %i ' % job_summary['finished_jobs'])
     log.info('Skipped jobs: %i ' % job_summary['skipped_jobs'])
     log.info('Failed jobs: %i ' % job_summary['failed_jobs'])

--- a/ephemeris/run_data_managers.py
+++ b/ephemeris/run_data_managers.py
@@ -26,8 +26,10 @@ import logging as log
 import time
 
 import yaml
+from bioblend import ConnectionError
 from bioblend.galaxy import GalaxyInstance
 from bioblend.galaxy.tool_data import ToolDataClient
+
 from jinja2 import Template
 
 
@@ -184,9 +186,27 @@ def run_dm(args):
                 number_skipped_jobs += 1
             else:
                 # run the DM-job
-                job = gi.tools.run_tool(history_id=None, tool_id=dm_id, tool_inputs=inputs)
-                log.info('Dispatched job %i. Running DM: "%s" with parameters: %s' % (job['outputs'][0]['hid'], dm_id, inputs))
-                job_list.append(job)
+                for attempt in range(args.retry_attempts):
+                    try:
+                        job = gi.tools.run_tool(history_id=None, tool_id=dm_id, tool_inputs=inputs)
+                        log.info('Dispatched job %i. Running DM: "%s" with parameters: %s' % (job['outputs'][0]['hid'], dm_id, inputs))
+                        job_list.append(job)
+                        break
+                    except ConnectionError as e:
+                        wait_time = 30
+                        attempts_left = args.retry_attempts - (attempt + 1)
+                        log.error("Connection error: %s", e)
+                        if attempts_left <= 0:
+                            log.error("No attempts left")
+                            if not args.ignore_erros:
+                                raise Exception('Could not run DM: "%s" with parameters: "%s"' % (dm_id, inputs))
+                            else:
+                                # Ignore and try next job
+                                break
+                        else:
+                            log.error("Retrying in %i seconds, %i attempts left..." % (wait_time, attempts_left))
+                            time.sleep(wait_time)
+
         succesfull_jobs, failed_jobs = wait(gi, job_list)
         if failed_jobs:
             if not args.ignore_errors:
@@ -216,6 +236,8 @@ def _parser():
                         help="Disables checking whether the item already exists in the tool data table.")
     parser.add_argument("--ignore_errors", action="store_true",
                         help="Do not stop running when jobs have failed.")
+    parser.add_argument("--retry_attempts", metavar='N', type=int, default=3,
+                        help="If a job can not submitted due to a connection error run-data-manager will try N times.")
     return parser
 
 

--- a/ephemeris/run_data_managers.py
+++ b/ephemeris/run_data_managers.py
@@ -45,7 +45,7 @@ def wait(gi, job_list):
     while bool(job_list):
         for job in job_list:
             value = job['outputs']
-            job_id = job.get('hid')
+            job_id = job['outputs'][0]['hid']
             # check if the output of the running job is either in 'ok' or 'error' state
             state = gi.datasets.show_dataset(value[0]['id'])['state']
             if state in ['ok', 'error']:
@@ -163,7 +163,7 @@ def run_dm(args):
                 log.info('Running DM: "%s" with parameters: %s' % (dm_id, inputs))
                 # run the DM-job
                 job = gi.tools.run_tool(history_id=None, tool_id=dm_id, tool_inputs=inputs)
-                log.info('Dispatched job %i. Running DM: "%s" with parameters: %s' % (job.get('hid'),dm_id, inputs))
+                log.info('Dispatched job %i. Running DM: "%s" with parameters: %s' % (job['outputs'][0]['hid'],dm_id, inputs))
                 job_list.append(job)
         wait(gi, job_list)
 

--- a/ephemeris/sleep.py
+++ b/ephemeris/sleep.py
@@ -54,7 +54,7 @@ def main():
                 break
             except ValueError:
                 if options.verbose:
-                    sys.stdout.write("[%02d] No valid json returned... %s\n" % (count,result.__str__()))
+                    sys.stdout.write("[%02d] No valid json returned... %s\n" % (count, result.__str__()))
                     sys.stdout.flush()
         except requests.exceptions.ConnectionError as e:
             if options.verbose:

--- a/ephemeris/sleep.py
+++ b/ephemeris/sleep.py
@@ -46,10 +46,16 @@ def main():
     count = 0
     while True:
         try:
-            result = requests.get(options.galaxy + '/api/version').json()
-            if options.verbose:
-                sys.stdout.write("Galaxy Version: %s\n" % result['version_major'])
-            break
+            result = requests.get(options.galaxy + '/api/version')
+            try:
+                result = result.json()
+                if options.verbose:
+                    sys.stdout.write("Galaxy Version: %s\n" % result['version_major'])
+                break
+            except ValueError:
+                if options.verbose:
+                    sys.stdout.write("[%02d] No valid json returned... %s\n" % (count,result.__str__()))
+                    sys.stdout.flush()
         except requests.exceptions.ConnectionError as e:
             if options.verbose:
                 sys.stdout.write("[%02d] Galaxy not up yet... %s\n" % (count, str(e)[0:100]))

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
 six>=1.9.0
 pyyaml
-bioblend>=0.9.0
+bioblend>=0.10.0
 Jinja2

--- a/tests/run_data_managers.yaml.test
+++ b/tests/run_data_managers.yaml.test
@@ -3,7 +3,12 @@ genomes:
     - accession: NC_001617.1
       name: RhinoVirus A (NC_001617.1)
       id: RhinoVirusA
-
+    - accession: AC_000007.1
+      name: Human adenovirus 2 (AC_000007.1)
+      id: HumAdeno2
+    - accession: KF039736.1
+      name: Norovirus Hu/GI.1/CHA7A011/2010/USA
+      id: NoroVirCHA7A011
 
 data_managers:
     - id: toolshed.g2.bx.psu.edu/repos/devteam/data_manager_fetch_genome_dbkeys_all_fasta/data_manager_fetch_genome_all_fasta_dbkey/0.0.2

--- a/tests/test.sh
+++ b/tests/test.sh
@@ -1,6 +1,7 @@
 #!/usr/bin/env bash
 
-set -e
+set -eu
+set -o pipefail
 
 CURRENT_DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"
 TEST_DATA=${EPHEMERIS_TEST_DATA:-"$CURRENT_DIR"}
@@ -20,21 +21,26 @@ echo "Starting galaxy docker container"
 CID=`docker run -d -e GALAXY_CONFIG_WATCH_TOOL_DATA_DIR=True -P bgruening/galaxy-stable`
 # We get the webport (https://docs.docker.com/engine/reference/commandline/inspect/#list-all-port-bindings)
 WEB_PORT=`docker inspect --format="{{(index (index .NetworkSettings.Ports \"$INTERNAL_EXPOSED_WEB_PORT/tcp\") 0).HostPort}}" $CID`
-galaxy-wait -g http://localhost:$WEB_PORT
+echo "test galaxy-wait function"
+galaxy-wait -g http://localhost:$WEB_PORT -v
 docker ps
 
 echo "Check tool installation"
 shed-install -t "$TEST_DATA"/tool_list.yaml.sample -a admin -g http://localhost:$WEB_PORT
 shed-install -t "$TEST_DATA"/tool_list.yaml.sample --user admin@galaxy.org -p admin -g http://localhost:$WEB_PORT
+
+echo "restarting galaxy"
 #We restart galaxy because otherwise the data manager tables won't be watched
-docker exec $CID supervisorctl restart galaxy: && galaxy-wait -g http://localhost:$WEB_PORT
+docker exec $CID supervisorctl restart galaxy:
+echo "wait for galaxy to start"
+galaxy-wait -g http://localhost:$WEB_PORT -v
 
 echo "Check workflow installation"
 workflow-install --user admin@galaxy.org -p admin -g http://localhost:$WEB_PORT -w "$TEST_DATA"/test_workflow.ga
 workflow-install -a admin -g http://localhost:$WEB_PORT -w "$TEST_DATA"/test_workflow.ga
 
 echo "Populate data libraries"
-setup-data-libraries --user admin@galaxy.org -p admin -g http://localhost:$WEB_PORT -i "$TET_DATA"/library_data_example.yaml
+setup-data-libraries --user admin@galaxy.org -p admin -g http://localhost:$WEB_PORT -i "$TEST_DATA"/library_data_example.yaml
 setup-data-libraries -a admin -g http://localhost:$WEB_PORT -i "$TEST_DATA"/library_data_example.yaml
 
 echo "Get tool list from Galaxy"
@@ -46,7 +52,7 @@ shed-install -t result_workflow_to_tools.yaml -a admin -g http://localhost:$WEB_
 shed-install -t result_workflow_to_tools.yaml --user admin@galaxy.org -p admin -g http://localhost:$WEB_PORT
 
 echo "Check installation of reference genomes"
-run-data-managers --user admin@galaxy.org -p admin -g http://localhost:$WEB_PORT --config ./run_data_managers.yaml.test -v
+run-data-managers --user admin@galaxy.org -p admin -g http://localhost:$WEB_PORT --config "$TEST_DATA"/run_data_managers.yaml.test -v
 echo "Small waiting step to allow data-tables to update"
 # This seems to be necessary on travis
 sleep 15

--- a/tests/test.sh
+++ b/tests/test.sh
@@ -18,7 +18,10 @@ echo "Starting galaxy docker container"
 # We start the image with the -P flag that published all exposed container ports
 # to random free ports on the host, since on OS X the container can't be reached
 # through the internal network (https://docs.docker.com/docker-for-mac/networking/#i-cannot-ping-my-containers)
-CID=`docker run -d -e GALAXY_CONFIG_WATCH_TOOL_DATA_DIR=True -P bgruening/galaxy-stable`
+# We start the image with the following environment variables:
+# GALAXY_CONFIG_WATCH_TOOL_DATA_DIR=True  this is needed for run_data_managers
+# GALAXY_HANDLER_NUMPROCS=1   this will prevent to handler processes editing the same data table at the same time.
+CID=`docker run -d -e GALAXY_CONFIG_WATCH_TOOL_DATA_DIR=True -e GALAXY_HANDLER_NUMPROCS=1 -P bgruening/galaxy-stable`
 # We get the webport (https://docs.docker.com/engine/reference/commandline/inspect/#list-all-port-bindings)
 WEB_PORT=`docker inspect --format="{{(index (index .NetworkSettings.Ports \"$INTERNAL_EXPOSED_WEB_PORT/tcp\") 0).HostPort}}" $CID`
 echo "Test galaxy-wait function"

--- a/tests/test.sh
+++ b/tests/test.sh
@@ -22,7 +22,7 @@ CID=`docker run -d -e GALAXY_CONFIG_WATCH_TOOL_DATA_DIR=True -P bgruening/galaxy
 # We get the webport (https://docs.docker.com/engine/reference/commandline/inspect/#list-all-port-bindings)
 WEB_PORT=`docker inspect --format="{{(index (index .NetworkSettings.Ports \"$INTERNAL_EXPOSED_WEB_PORT/tcp\") 0).HostPort}}" $CID`
 echo "test galaxy-wait function"
-galaxy-wait -g http://localhost:$WEB_PORT -v -t 120
+galaxy-wait -g http://localhost:$WEB_PORT -v --timeout 120
 docker ps
 
 echo "Check tool installation"
@@ -33,7 +33,7 @@ echo "restarting galaxy"
 #We restart galaxy because otherwise the data manager tables won't be watched
 docker exec $CID supervisorctl restart galaxy:
 echo "wait for galaxy to start"
-galaxy-wait -g http://localhost:$WEB_PORT -v -t 120
+galaxy-wait -g http://localhost:$WEB_PORT -v --timeout 120
 
 echo "Check workflow installation"
 workflow-install --user admin@galaxy.org -p admin -g http://localhost:$WEB_PORT -w "$TEST_DATA"/test_workflow.ga

--- a/tests/test.sh
+++ b/tests/test.sh
@@ -43,7 +43,7 @@ echo "Check installation of reference genomes"
 #run-data-managers --user admin@galaxy.org -p admin -g http://localhost:$WEB_PORT --config ./run_data_managers.yaml.test -v
 run-data-managers -a admin -g http://localhost:$WEB_PORT --config "$TEST_DATA"/run_data_managers.yaml.test
 echo "Check if installation is skipped when reference genomes are already installed."
-run-data-managers -a admin -g http://localhost:$WEB_PORT --config "$TEST_DATA"/run_data_managers.yaml.test  >> data_manager_output.txt 2>&1
+run-data-managers -a admin -g http://localhost:$WEB_PORT --config "$TEST_DATA"/run_data_managers.yaml.test  >> data_manager_output.txt
 # Check if already installed was thrown
 echo $(cat data_manager_output.txt | grep -i "already run for")
 data_manager_already_installed=$(cat data_manager_output.txt | grep -i "already run for" -c)

--- a/tests/test.sh
+++ b/tests/test.sh
@@ -24,24 +24,23 @@ sleep 120s
 docker ps
 echo "Check tool installation"
 shed-install -t "$TEST_DATA"/tool_list.yaml.sample -a admin -g http://localhost:$WEB_PORT
-#shed-install -t "$TEST_DATA"/tool_list.yaml.sample --user admin@galaxy.org -p admin -g http://localhost:$WEB_PORT
+shed-install -t "$TEST_DATA"/tool_list.yaml.sample --user admin@galaxy.org -p admin -g http://localhost:$WEB_PORT
 #We restart galaxy because otherwise the data manager tables won't be watched
 docker exec $CID supervisorctl restart galaxy: && sleep 60s
 echo "Check workflow installation"
-#workflow-install --user admin@galaxy.org -p admin -g http://localhost:$WEB_PORT -w "$TEST_DATA"/test_workflow.ga
+workflow-install --user admin@galaxy.org -p admin -g http://localhost:$WEB_PORT -w "$TEST_DATA"/test_workflow.ga
 workflow-install -a admin -g http://localhost:$WEB_PORT -w "$TEST_DATA"/test_workflow.ga
 echo "Populate data libraries"
-#setup-data-libraries --user admin@galaxy.org -p admin -g http://localhost:$WEB_PORT -i "$TET_DATA"/library_data_example.yaml
+setup-data-libraries --user admin@galaxy.org -p admin -g http://localhost:$WEB_PORT -i "$TET_DATA"/library_data_example.yaml
 setup-data-libraries -a admin -g http://localhost:$WEB_PORT -i "$TEST_DATA"/library_data_example.yaml
 echo "Get tool list from Galaxy"
 get-tool-list -g http://localhost:$WEB_PORT -o result_tool_list.yaml
 workflow-to-tools -w "$TEST_DATA"/test_workflow_2.ga -o result_workflow_to_tools.yaml
 echo "Check tool installation from workflow"
 shed-install -t result_workflow_to_tools.yaml -a admin -g http://localhost:$WEB_PORT
-#shed-install -t result_workflow_to_tools.yaml --user admin@galaxy.org -p admin -g http://localhost:$WEB_PORT
+shed-install -t result_workflow_to_tools.yaml --user admin@galaxy.org -p admin -g http://localhost:$WEB_PORT
 echo "Check installation of reference genomes"
-#run-data-managers --user admin@galaxy.org -p admin -g http://localhost:$WEB_PORT --config ./run_data_managers.yaml.test -v
-run-data-managers -a admin -g http://localhost:$WEB_PORT --config "$TEST_DATA"/run_data_managers.yaml.test
+run-data-managers --user admin@galaxy.org -p admin -g http://localhost:$WEB_PORT --config ./run_data_managers.yaml.test -v
 echo "Check if installation is skipped when reference genomes are already installed."
 run-data-managers -a admin -g http://localhost:$WEB_PORT --config "$TEST_DATA"/run_data_managers.yaml.test &> data_manager_output.txt
 # Check if already installed was thrown

--- a/tests/test.sh
+++ b/tests/test.sh
@@ -18,10 +18,7 @@ echo "Starting galaxy docker container"
 # We start the image with the -P flag that published all exposed container ports
 # to random free ports on the host, since on OS X the container can't be reached
 # through the internal network (https://docs.docker.com/docker-for-mac/networking/#i-cannot-ping-my-containers)
-# We start the image with the following environment variables:
-# GALAXY_CONFIG_WATCH_TOOL_DATA_DIR=True  this is needed for run_data_managers
-# GALAXY_HANDLER_NUMPROCS=1   this will prevent to handler processes editing the same data table at the same time.
-CID=`docker run -d -e GALAXY_CONFIG_WATCH_TOOL_DATA_DIR=True -e GALAXY_HANDLER_NUMPROCS=1 -P bgruening/galaxy-stable`
+CID=`docker run -d -e GALAXY_CONFIG_WATCH_TOOL_DATA_DIR=True -P bgruening/galaxy-stable`
 # We get the webport (https://docs.docker.com/engine/reference/commandline/inspect/#list-all-port-bindings)
 WEB_PORT=`docker inspect --format="{{(index (index .NetworkSettings.Ports \"$INTERNAL_EXPOSED_WEB_PORT/tcp\") 0).HostPort}}" $CID`
 echo "Test galaxy-wait function"

--- a/tests/test.sh
+++ b/tests/test.sh
@@ -21,7 +21,7 @@ echo "Starting galaxy docker container"
 CID=`docker run -d -e GALAXY_CONFIG_WATCH_TOOL_DATA_DIR=True -P bgruening/galaxy-stable`
 # We get the webport (https://docs.docker.com/engine/reference/commandline/inspect/#list-all-port-bindings)
 WEB_PORT=`docker inspect --format="{{(index (index .NetworkSettings.Ports \"$INTERNAL_EXPOSED_WEB_PORT/tcp\") 0).HostPort}}" $CID`
-echo "test galaxy-wait function"
+echo "Test galaxy-wait function"
 galaxy-wait -g http://localhost:$WEB_PORT -v --timeout 120
 docker ps
 
@@ -29,10 +29,10 @@ echo "Check tool installation"
 shed-install -t "$TEST_DATA"/tool_list.yaml.sample -a admin -g http://localhost:$WEB_PORT
 shed-install -t "$TEST_DATA"/tool_list.yaml.sample --user admin@galaxy.org -p admin -g http://localhost:$WEB_PORT
 
-echo "restarting galaxy"
+echo "Restarting galaxy"
 #We restart galaxy because otherwise the data manager tables won't be watched
 docker exec $CID supervisorctl restart galaxy:
-echo "wait for galaxy to start"
+echo "Wait for galaxy to start"
 galaxy-wait -g http://localhost:$WEB_PORT -v --timeout 120
 
 echo "Check workflow installation"

--- a/tests/test.sh
+++ b/tests/test.sh
@@ -43,11 +43,11 @@ echo "Check installation of reference genomes"
 #run-data-managers --user admin@galaxy.org -p admin -g http://localhost:$WEB_PORT --config ./run_data_managers.yaml.test -v
 run-data-managers -a admin -g http://localhost:$WEB_PORT --config "$TEST_DATA"/run_data_managers.yaml.test
 echo "Check if installation is skipped when reference genomes are already installed."
-run-data-managers -a admin -g http://localhost:$WEB_PORT --config "$TEST_DATA"/run_data_managers.yaml.test  > data_manager_output.txt
+run-data-managers -a admin -g http://localhost:$WEB_PORT --config "$TEST_DATA"/run_data_managers.yaml.test &> data_manager_output.txt
 # Check if already installed was thrown
-echo $(cat data_manager_output.txt | grep -i "already run for")
-data_manager_already_installed=$(cat data_manager_output.txt | grep -i "already run for" -c)
-if [ $data_manager_already_installed -ne 6 ]
+cat data_manager_output.txt
+data_manager_already_installed=$(cat data_manager_output.txt | grep -i "Skipped jobs: 6" -c)
+if [ $data_manager_already_installed -ne 1 ]
     then
         echo "ERROR: Not all already installed genomes were skipped"
         exit 1

--- a/tests/test.sh
+++ b/tests/test.sh
@@ -56,13 +56,16 @@ shed-install -t result_workflow_to_tools.yaml --user admin@galaxy.org -p admin -
 
 echo "Check installation of reference genomes"
 run-data-managers --user admin@galaxy.org -p admin -g http://localhost:$WEB_PORT --config "$TEST_DATA"/run_data_managers.yaml.test
+
 echo "Small waiting step to allow data-tables to update"
 # This seems to be necessary on travis
 sleep 15
+
 echo "Check if installation is skipped when reference genomes are already installed."
 run-data-managers -a admin -g http://localhost:$WEB_PORT --config "$TEST_DATA"/run_data_managers.yaml.test &> data_manager_output.txt
 # Check if already installed was thrown
 cat data_manager_output.txt
+
 echo "Number of skipped jobs should be 6"
 data_manager_already_installed=$(cat data_manager_output.txt | grep -i "Skipped jobs: 6" -c)
 if [ $data_manager_already_installed -ne 1 ]

--- a/tests/test.sh
+++ b/tests/test.sh
@@ -43,7 +43,7 @@ echo "Check installation of reference genomes"
 #run-data-managers --user admin@galaxy.org -p admin -g http://localhost:$WEB_PORT --config ./run_data_managers.yaml.test -v
 run-data-managers -a admin -g http://localhost:$WEB_PORT --config "$TEST_DATA"/run_data_managers.yaml.test
 echo "Check if installation is skipped when reference genomes are already installed."
-run-data-managers -a admin -g http://localhost:$WEB_PORT --config "$TEST_DATA"/run_data_managers.yaml.test  >> data_manager_output.txt
+run-data-managers -a admin -g http://localhost:$WEB_PORT --config "$TEST_DATA"/run_data_managers.yaml.test  > data_manager_output.txt
 # Check if already installed was thrown
 echo $(cat data_manager_output.txt | grep -i "already run for")
 data_manager_already_installed=$(cat data_manager_output.txt | grep -i "already run for" -c)

--- a/tests/test.sh
+++ b/tests/test.sh
@@ -47,7 +47,7 @@ run-data-managers -a admin -g http://localhost:$WEB_PORT --config "$TEST_DATA"/r
 # Check if already installed was thrown
 echo $(cat data_manager_output.txt | grep -i "already run for")
 data_manager_already_installed=$(cat data_manager_output.txt | grep -i "already run for" -c)
-if [ $data_manager_already_installed -ne 2 ]
+if [ $data_manager_already_installed -ne 6 ]
     then
         echo "ERROR: Not all already installed genomes were skipped"
         exit 1

--- a/tests/test.sh
+++ b/tests/test.sh
@@ -20,13 +20,13 @@ echo "Starting galaxy docker container"
 CID=`docker run -d -e GALAXY_CONFIG_WATCH_TOOL_DATA_DIR=True -P bgruening/galaxy-stable`
 # We get the webport (https://docs.docker.com/engine/reference/commandline/inspect/#list-all-port-bindings)
 WEB_PORT=`docker inspect --format="{{(index (index .NetworkSettings.Ports \"$INTERNAL_EXPOSED_WEB_PORT/tcp\") 0).HostPort}}" $CID`
-sleep 120s
+galaxy-wait http://localhost:$WEB_PORT
 docker ps
 echo "Check tool installation"
 shed-install -t "$TEST_DATA"/tool_list.yaml.sample -a admin -g http://localhost:$WEB_PORT
 shed-install -t "$TEST_DATA"/tool_list.yaml.sample --user admin@galaxy.org -p admin -g http://localhost:$WEB_PORT
 #We restart galaxy because otherwise the data manager tables won't be watched
-docker exec $CID supervisorctl restart galaxy: && sleep 60s
+docker exec $CID supervisorctl restart galaxy: && galaxy-wait http://localhost:$WEB_PORT
 echo "Check workflow installation"
 workflow-install --user admin@galaxy.org -p admin -g http://localhost:$WEB_PORT -w "$TEST_DATA"/test_workflow.ga
 workflow-install -a admin -g http://localhost:$WEB_PORT -w "$TEST_DATA"/test_workflow.ga

--- a/tests/test.sh
+++ b/tests/test.sh
@@ -29,6 +29,9 @@ echo "Check tool installation"
 shed-install -t "$TEST_DATA"/tool_list.yaml.sample -a admin -g http://localhost:$WEB_PORT
 shed-install -t "$TEST_DATA"/tool_list.yaml.sample --user admin@galaxy.org -p admin -g http://localhost:$WEB_PORT
 
+echo "Wait a few seconds before restarting galaxy"
+sleep 15
+
 echo "Restarting galaxy"
 #We restart galaxy because otherwise the data manager tables won't be watched
 docker exec $CID supervisorctl restart galaxy:

--- a/tests/test.sh
+++ b/tests/test.sh
@@ -22,7 +22,7 @@ CID=`docker run -d -e GALAXY_CONFIG_WATCH_TOOL_DATA_DIR=True -P bgruening/galaxy
 # We get the webport (https://docs.docker.com/engine/reference/commandline/inspect/#list-all-port-bindings)
 WEB_PORT=`docker inspect --format="{{(index (index .NetworkSettings.Ports \"$INTERNAL_EXPOSED_WEB_PORT/tcp\") 0).HostPort}}" $CID`
 echo "test galaxy-wait function"
-galaxy-wait -g http://localhost:$WEB_PORT -v
+galaxy-wait -g http://localhost:$WEB_PORT -v -t 120
 docker ps
 
 echo "Check tool installation"
@@ -33,7 +33,7 @@ echo "restarting galaxy"
 #We restart galaxy because otherwise the data manager tables won't be watched
 docker exec $CID supervisorctl restart galaxy:
 echo "wait for galaxy to start"
-galaxy-wait -g http://localhost:$WEB_PORT -v
+galaxy-wait -g http://localhost:$WEB_PORT -v -t 120
 
 echo "Check workflow installation"
 workflow-install --user admin@galaxy.org -p admin -g http://localhost:$WEB_PORT -w "$TEST_DATA"/test_workflow.ga

--- a/tests/test.sh
+++ b/tests/test.sh
@@ -52,7 +52,7 @@ shed-install -t result_workflow_to_tools.yaml -a admin -g http://localhost:$WEB_
 shed-install -t result_workflow_to_tools.yaml --user admin@galaxy.org -p admin -g http://localhost:$WEB_PORT
 
 echo "Check installation of reference genomes"
-run-data-managers --user admin@galaxy.org -p admin -g http://localhost:$WEB_PORT --config "$TEST_DATA"/run_data_managers.yaml.test -v
+run-data-managers --user admin@galaxy.org -p admin -g http://localhost:$WEB_PORT --config "$TEST_DATA"/run_data_managers.yaml.test
 echo "Small waiting step to allow data-tables to update"
 # This seems to be necessary on travis
 sleep 15

--- a/tests/test.sh
+++ b/tests/test.sh
@@ -20,27 +20,36 @@ echo "Starting galaxy docker container"
 CID=`docker run -d -e GALAXY_CONFIG_WATCH_TOOL_DATA_DIR=True -P bgruening/galaxy-stable`
 # We get the webport (https://docs.docker.com/engine/reference/commandline/inspect/#list-all-port-bindings)
 WEB_PORT=`docker inspect --format="{{(index (index .NetworkSettings.Ports \"$INTERNAL_EXPOSED_WEB_PORT/tcp\") 0).HostPort}}" $CID`
-galaxy-wait http://localhost:$WEB_PORT
+galaxy-wait -g http://localhost:$WEB_PORT
 docker ps
+
 echo "Check tool installation"
 shed-install -t "$TEST_DATA"/tool_list.yaml.sample -a admin -g http://localhost:$WEB_PORT
 shed-install -t "$TEST_DATA"/tool_list.yaml.sample --user admin@galaxy.org -p admin -g http://localhost:$WEB_PORT
 #We restart galaxy because otherwise the data manager tables won't be watched
-docker exec $CID supervisorctl restart galaxy: && galaxy-wait http://localhost:$WEB_PORT
+docker exec $CID supervisorctl restart galaxy: && galaxy-wait -g http://localhost:$WEB_PORT
+
 echo "Check workflow installation"
 workflow-install --user admin@galaxy.org -p admin -g http://localhost:$WEB_PORT -w "$TEST_DATA"/test_workflow.ga
 workflow-install -a admin -g http://localhost:$WEB_PORT -w "$TEST_DATA"/test_workflow.ga
+
 echo "Populate data libraries"
 setup-data-libraries --user admin@galaxy.org -p admin -g http://localhost:$WEB_PORT -i "$TET_DATA"/library_data_example.yaml
 setup-data-libraries -a admin -g http://localhost:$WEB_PORT -i "$TEST_DATA"/library_data_example.yaml
+
 echo "Get tool list from Galaxy"
 get-tool-list -g http://localhost:$WEB_PORT -o result_tool_list.yaml
 workflow-to-tools -w "$TEST_DATA"/test_workflow_2.ga -o result_workflow_to_tools.yaml
+
 echo "Check tool installation from workflow"
 shed-install -t result_workflow_to_tools.yaml -a admin -g http://localhost:$WEB_PORT
 shed-install -t result_workflow_to_tools.yaml --user admin@galaxy.org -p admin -g http://localhost:$WEB_PORT
+
 echo "Check installation of reference genomes"
 run-data-managers --user admin@galaxy.org -p admin -g http://localhost:$WEB_PORT --config ./run_data_managers.yaml.test -v
+echo "Small waiting step to allow data-tables to update"
+# This seems to be necessary on travis
+sleep 15
 echo "Check if installation is skipped when reference genomes are already installed."
 run-data-managers -a admin -g http://localhost:$WEB_PORT --config "$TEST_DATA"/run_data_managers.yaml.test &> data_manager_output.txt
 # Check if already installed was thrown
@@ -52,5 +61,6 @@ if [ $data_manager_already_installed -ne 1 ]
         echo "ERROR: Not all already installed genomes were skipped"
         exit 1
 fi
+
 # Remove running container
 docker rm -f $CID

--- a/tests/test.sh
+++ b/tests/test.sh
@@ -41,9 +41,9 @@ shed-install -t result_workflow_to_tools.yaml -a admin -g http://localhost:$WEB_
 #shed-install -t result_workflow_to_tools.yaml --user admin@galaxy.org -p admin -g http://localhost:$WEB_PORT
 echo "Check installation of reference genomes"
 #run-data-managers --user admin@galaxy.org -p admin -g http://localhost:$WEB_PORT --config ./run_data_managers.yaml.test -v
-run-data-managers -a admin -g http://localhost:$WEB_PORT --config "$TEST_DATA"/run_data_managers.yaml.test -v
+run-data-managers -a admin -g http://localhost:$WEB_PORT --config "$TEST_DATA"/run_data_managers.yaml.test
 echo "Check if installation is skipped when reference genomes are already installed."
-run-data-managers -a admin -g http://localhost:$WEB_PORT --config "$TEST_DATA"/run_data_managers.yaml.test -v >> data_manager_output.txt 2>&1
+run-data-managers -a admin -g http://localhost:$WEB_PORT --config "$TEST_DATA"/run_data_managers.yaml.test  >> data_manager_output.txt 2>&1
 # Check if already installed was thrown
 echo $(cat data_manager_output.txt | grep -i "already run for")
 data_manager_already_installed=$(cat data_manager_output.txt | grep -i "already run for" -c)

--- a/tests/test.sh
+++ b/tests/test.sh
@@ -46,6 +46,7 @@ echo "Check if installation is skipped when reference genomes are already instal
 run-data-managers -a admin -g http://localhost:$WEB_PORT --config "$TEST_DATA"/run_data_managers.yaml.test &> data_manager_output.txt
 # Check if already installed was thrown
 cat data_manager_output.txt
+echo "Number of skipped jobs should be 6"
 data_manager_already_installed=$(cat data_manager_output.txt | grep -i "Skipped jobs: 6" -c)
 if [ $data_manager_already_installed -ne 1 ]
     then


### PR DESCRIPTION
fixes #54 

~~The stdout of run-data-managers is not up to scratch though. It does not give any output. If the -v flag is used, it gives too much output (also debug messages). Can somebody show me how to get run-data-managers too display all the info messages in stdout?~~
