### PR TITLE
Also update data managers

### DIFF
--- a/ephemeris/__init__.py
+++ b/ephemeris/__init__.py
@@ -52,7 +52,7 @@ def load_yaml_file(filename):
     Load YAML from the `tool_list_file` and return a dict with the content.
     """
     with open(filename, 'r') as f:
-        dictionary = yaml.load(f)
+        dictionary = yaml.safe_load(f)
     return dictionary
 
 

--- a/ephemeris/__init__.py
+++ b/ephemeris/__init__.py
@@ -23,7 +23,7 @@ def check_url(url, log=None):
     return url
 
 
-def get_galaxy_connection(args, file=None, log=None):
+def get_galaxy_connection(args, file=None, log=None, login_required=True):
     """
     Return a Galaxy connection, given a user or an API key.
     If not given gets the arguments from the file.
@@ -42,6 +42,8 @@ def get_galaxy_connection(args, file=None, log=None):
         return galaxy.GalaxyInstance(url=galaxy_url, email=args.user, password=args.password)
     elif api_key:
         return galaxy.GalaxyInstance(url=galaxy_url, key=api_key)
+    elif not login_required:
+        return galaxy.GalaxyInstance(url=galaxy_url)
     return None
 
 

--- a/ephemeris/get_tool_list_from_galaxy.py
+++ b/ephemeris/get_tool_list_from_galaxy.py
@@ -11,7 +11,6 @@ from bioblend.galaxy import GalaxyInstance
 from bioblend.galaxy.tools import ToolClient
 
 from . import get_galaxy_connection
-from . import check_url
 from .common_parser import get_common_args
 
 
@@ -188,7 +187,7 @@ def check_galaxy_version(gi):
 
 def main():
     options = _parse_cli_options()
-    gi = get_galaxy_connection(options)
+    gi = get_galaxy_connection(options, login_required=False)
     check_galaxy_version(gi)
     gi_to_tool_yaml = GiToToolYaml(
         gi=gi,

--- a/ephemeris/get_tool_list_from_galaxy.py
+++ b/ephemeris/get_tool_list_from_galaxy.py
@@ -7,7 +7,6 @@ from argparse import ArgumentParser
 from distutils.version import StrictVersion
 
 import yaml
-from bioblend.galaxy import GalaxyInstance
 from bioblend.galaxy.tools import ToolClient
 
 from . import get_galaxy_connection
@@ -24,7 +23,7 @@ class GiToToolYaml:
         self.include_tool_panel_section_id = include_tool_panel_section_id
         self.skip_tool_panel_section_name = skip_tool_panel_section_name
         self.skip_changeset_revision = skip_changeset_revision
-        self.get_data_managers=get_data_managers
+        self.get_data_managers = get_data_managers
         self.repository_list = self.get_repositories()
         self.repository_list = self.merge_tool_changeset_revisions()
         self.filter_section_name_or_id_or_changeset()
@@ -66,8 +65,6 @@ class GiToToolYaml:
             for tool in self.tool_list:
                 if tool.get("model_class") == 'DataManagerTool':
                     repositories.append(self.get_repo_from_tool(tool))
-
-
         return repositories
 
     def get_repo_from_tool(self, tool):

--- a/ephemeris/get_tool_list_from_galaxy.py
+++ b/ephemeris/get_tool_list_from_galaxy.py
@@ -67,8 +67,6 @@ class GiToToolYaml:
                     repositories.append(get_repo_from_tool(tool))
         return repositories
 
-
-
     def merge_tool_changeset_revisions(self):
         """
         Each installed changeset revision of a tool is listed individually.
@@ -141,6 +139,7 @@ def _parser():
                         help="Include the data managers in the tool list. Requires login details")
     return parser
 
+
 def get_repo_from_tool(tool):
     """
     Get the minimum items required for re-installing a (list of) tools
@@ -156,6 +155,7 @@ def get_repo_from_tool(tool):
             'tool_panel_section_label': tool['panel_section_name']}
     return repo
 
+
 def get_repos_from_section(section):
     repos = []
     for elem in section['elems']:
@@ -168,6 +168,7 @@ def get_repos_from_section(section):
             if new_repos:
                 repos.extend(new_repos)
     return repos
+
 
 def _parse_cli_options():
     """

--- a/ephemeris/get_tool_list_from_galaxy.py
+++ b/ephemeris/get_tool_list_from_galaxy.py
@@ -18,12 +18,13 @@ class GiToToolYaml:
     def __init__(self, gi,
                  include_tool_panel_section_id=False,
                  skip_tool_panel_section_name=True,
-                 skip_changeset_revision=False):
-
+                 skip_changeset_revision=False,
+                 get_data_managers=False):
         self.gi = gi
         self.include_tool_panel_section_id = include_tool_panel_section_id
         self.skip_tool_panel_section_name = skip_tool_panel_section_name
         self.skip_changeset_revision = skip_changeset_revision
+        self.get_data_managers=get_data_managers
         self.repository_list = self.get_repositories()
         self.repository_list = self.merge_tool_changeset_revisions()
         self.filter_section_name_or_id_or_changeset()
@@ -46,6 +47,10 @@ class GiToToolYaml:
         for elem in self.toolbox:
             if elem['model_class'] == 'Tool':
                 repo = self.get_repo_from_tool(elem)
+                if repo:
+                    repositories.append(repo)
+            if self.get_data_managers and elem['model_class'] == 'DataManagerTool':
+                repo=self.get_repo_from_tool(elem)
                 if repo:
                     repositories.append(repo)
             elif elem['model_class'] == 'ToolSection':

--- a/ephemeris/get_tool_list_from_galaxy.py
+++ b/ephemeris/get_tool_list_from_galaxy.py
@@ -38,7 +38,7 @@ class GiToToolYaml:
         return tool_client.get_tool_panel()
 
     @property
-    def tool_list(self):
+    def installed_tool_list(self):
         """
         gets a tool list from the toolclient
         :return:
@@ -62,7 +62,7 @@ class GiToToolYaml:
                 if new_repos:
                     repositories.extend(new_repos)
         if self.get_data_managers:
-            for tool in self.tool_list:
+            for tool in self.installed_tool_list:
                 if tool.get("model_class") == 'DataManagerTool':
                     repositories.append(self.get_repo_from_tool(tool))
         return repositories

--- a/ephemeris/get_tool_list_from_galaxy.py
+++ b/ephemeris/get_tool_list_from_galaxy.py
@@ -54,46 +54,20 @@ class GiToToolYaml:
         repositories = []
         for elem in self.toolbox:
             if elem['model_class'] == 'Tool':
-                repo = self.get_repo_from_tool(elem)
+                repo = get_repo_from_tool(elem)
                 if repo:
                     repositories.append(repo)
             elif elem['model_class'] == 'ToolSection':
-                new_repos = self.get_repos_from_section(elem)
+                new_repos = get_repos_from_section(elem)
                 if new_repos:
                     repositories.extend(new_repos)
         if self.get_data_managers:
             for tool in self.installed_tool_list:
                 if tool.get("model_class") == 'DataManagerTool':
-                    repositories.append(self.get_repo_from_tool(tool))
+                    repositories.append(get_repo_from_tool(tool))
         return repositories
 
-    def get_repo_from_tool(self, tool):
-        """
-        Get the minimum items required for re-installing a (list of) tools
-        """
-        if not tool.get('tool_shed_repository', None):
-            return {}
-        tsr = tool['tool_shed_repository']
-        repo = {'name': tsr['name'],
-                'owner': tsr['owner'],
-                'tool_shed_url': tsr['tool_shed'],
-                'revisions': [tsr['changeset_revision']],
-                'tool_panel_section_id': tool['panel_section_id'],
-                'tool_panel_section_label': tool['panel_section_name']}
-        return repo
 
-    def get_repos_from_section(self, section):
-        repos = []
-        for elem in section['elems']:
-            if elem['model_class'] == 'Tool':
-                repo = self.get_repo_from_tool(elem)
-                if repo:
-                    repos.append(repo)
-            elif elem['model_class'] == 'ToolSection':
-                new_repos = self.get_repos_from_section(elem)
-                if new_repos:
-                    repos.extend(new_repos)
-        return repos
 
     def merge_tool_changeset_revisions(self):
         """
@@ -167,6 +141,33 @@ def _parser():
                         help="Include the data managers in the tool list. Requires login details")
     return parser
 
+def get_repo_from_tool(tool):
+    """
+    Get the minimum items required for re-installing a (list of) tools
+    """
+    if not tool.get('tool_shed_repository', None):
+        return {}
+    tsr = tool['tool_shed_repository']
+    repo = {'name': tsr['name'],
+            'owner': tsr['owner'],
+            'tool_shed_url': tsr['tool_shed'],
+            'revisions': [tsr['changeset_revision']],
+            'tool_panel_section_id': tool['panel_section_id'],
+            'tool_panel_section_label': tool['panel_section_name']}
+    return repo
+
+def get_repos_from_section(section):
+    repos = []
+    for elem in section['elems']:
+        if elem['model_class'] == 'Tool':
+            repo = get_repo_from_tool(elem)
+            if repo:
+                repos.append(repo)
+        elif elem['model_class'] == 'ToolSection':
+            new_repos = get_repos_from_section(elem)
+            if new_repos:
+                repos.extend(new_repos)
+    return repos
 
 def _parse_cli_options():
     """

--- a/ephemeris/get_tool_list_from_galaxy.py
+++ b/ephemeris/get_tool_list_from_galaxy.py
@@ -76,7 +76,7 @@ class GiToToolYaml:
         """
         repositories = {}
         repo_key_template = "{tool_shed_url}|{name}|{owner}|{tool_panel_section_id}|{tool_panel_section_label}"
-        for i, tool in enumerate(self.repository_list):
+        for tool in self.repository_list:
             repo_key = repo_key_template.format(**tool)
             if repo_key in repositories:
                 repositories[repo_key].extend(tool['revisions'])

--- a/ephemeris/get_tool_list_from_galaxy.py
+++ b/ephemeris/get_tool_list_from_galaxy.py
@@ -120,21 +120,21 @@ def _parser():
                         required=True,
                         dest="output",
                         help="tool_list.yml output file")
-    parser.add_argument("-include_id", "--include_tool_panel_id",
+    parser.add_argument("--include_tool_panel_id",
                         action="store_true",
                         help="Include tool_panel_id in tool_list.yml ? "
                              "Use this only if the tool panel id already exists. See "
                              "https://github.com/galaxyproject/ansible-galaxy-tools/blob/master/files/tool_list.yaml.sample")
-    parser.add_argument("-skip_name", "--skip_tool_panel_name",
+    parser.add_argument("--skip_tool_panel_name",
                         action="store_true",
                         help="Do not include tool_panel_name in tool_list.yml ?")
-    parser.add_argument("-skip_changeset", "--skip_changeset_revision",
+    parser.add_argument("--skip_changeset_revision",
                         action="store_true",
                         help="Do not include the changeset revision when generating the tool list."
                              "Use this if you would like to use the list to update all the tools in"
                              "your galaxy instance using shed-install."
                         )
-    parser.add_argument("-get_dms", "--get_data_managers",
+    parser.add_argument("--get_data_managers",
                         action="store_true",
                         help="Include the data managers in the tool list. Requires login details")
     return parser

--- a/ephemeris/get_tool_list_from_galaxy.py
+++ b/ephemeris/get_tool_list_from_galaxy.py
@@ -67,7 +67,7 @@ class GiToToolYaml:
             for tool in self.tool_list:
                 if tool.get("model_class") == 'DataManagerTool':
                     repositories.append(self.get_repo_from_tool(tool))
-                    repositories.append(self.get_repo_from_tool(tool))
+
 
         return repositories
 

--- a/ephemeris/get_tool_list_from_galaxy.py
+++ b/ephemeris/get_tool_list_from_galaxy.py
@@ -157,6 +157,9 @@ def _parser():
                              "Use this if you would like to use the list to update all the tools in"
                              "your galaxy instance using shed-install."
                         )
+    parser.add_argument("-get_dms", "--get_data_managers",
+                        action="store_true",
+                        help="Include the data managers in the tool list")
     return parser
 
 
@@ -183,7 +186,8 @@ def main():
         gi=gi,
         include_tool_panel_section_id=options.include_tool_panel_id,
         skip_tool_panel_section_name=options.skip_tool_panel_name,
-        skip_changeset_revision=options.skip_changeset_revision)
+        skip_changeset_revision=options.skip_changeset_revision,
+        get_data_managers=options.get_data_managers)
     gi_to_tool_yaml.write_to_yaml(options.output)
 
 

--- a/ephemeris/run_data_managers.py
+++ b/ephemeris/run_data_managers.py
@@ -27,11 +27,11 @@ import json
 import logging
 import time
 
-import yaml
 from bioblend.galaxy.tool_data import ToolDataClient
 from jinja2 import Template
 
 from . import get_galaxy_connection
+from . import load_yaml_file
 from .common_parser import get_common_args
 from .ephemeris_log import disable_external_library_logging, setup_global_logger
 
@@ -147,7 +147,8 @@ def parse_items(items, genomes):
 
 def run_dm(args):
     args.galaxy = args.galaxy or DEFAULT_URL
-    gi = get_galaxy_connection(args, log=log)
+    conf = load_yaml_file(args.config)
+    gi = get_galaxy_connection(args, log=log, file=args.config, login_required=True)
     # should test valid connection
     # The following should throw a ConnectionError when invalid API key or password
     genomes = gi.genomes.get_genomes()  # Does not get genomes but preconfigured dbkeys
@@ -158,9 +159,8 @@ def run_dm(args):
     number_skipped_jobs = 0
     all_failed_jobs = []
     all_successful_jobs = []
-
-    conf = yaml.load(open(args.config))
     genomes = conf.get('genomes', '')
+
     for dm in conf.get('data_managers'):
         items = parse_items(dm.get('items', ['']), genomes)
         job_list = []

--- a/ephemeris/run_data_managers.py
+++ b/ephemeris/run_data_managers.py
@@ -190,7 +190,6 @@ def run_dm(args):
         if failed_jobs:
             if not args.ignore_errors:
                 raise Exception('Not all jobs successful! aborting...')
-                break
             else:
                 log.error('Not all jobs successful! ignoring...')
         all_successful_jobs += successful_jobs

--- a/ephemeris/setup_data_libraries.py
+++ b/ephemeris/setup_data_libraries.py
@@ -23,7 +23,7 @@ def setup_data_libraries(gi, data):
 
     folders = dict()
 
-    libraries = yaml.load(data)
+    libraries = yaml.safe_load(data)
     for lib in libraries['libraries']:
         folders[lib['name']] = lib['files']
 

--- a/ephemeris/shed_tools.py
+++ b/ephemeris/shed_tools.py
@@ -40,6 +40,7 @@ import sys
 import time
 from argparse import ArgumentParser
 
+import yaml
 from bioblend.galaxy.client import ConnectionError
 from bioblend.galaxy.toolshed import ToolShedClient
 from bioblend.toolshed import ToolShedInstance
@@ -488,7 +489,7 @@ def get_install_repository_manager(options):
         install_tool_dependencies = repository_list.get(
             'install_tool_dependencies', INSTALL_TOOL_DEPENDENCIES)
     elif options.tool_yaml:
-        repositories = load_yaml_file(options.tool_yaml)
+        repositories = yaml.safe_load(options.tool_yaml)
     elif options.update_tools:
         get_repository_list = GiToToolYaml(
             gi=gi,

--- a/ephemeris/shed_tools.py
+++ b/ephemeris/shed_tools.py
@@ -489,7 +489,7 @@ def get_install_repository_manager(options):
         install_tool_dependencies = repository_list.get(
             'install_tool_dependencies', INSTALL_TOOL_DEPENDENCIES)
     elif options.tool_yaml:
-        repositories = yaml.safe_load(options.tool_yaml)
+        repositories = [yaml.safe_load(options.tool_yaml)]
     elif options.update_tools:
         get_repository_list = GiToToolYaml(
             gi=gi,

--- a/ephemeris/shed_tools.py
+++ b/ephemeris/shed_tools.py
@@ -493,7 +493,8 @@ def get_install_repository_manager(options):
     elif options.update_tools:
         get_repository_list = GiToToolYaml(
             gi=gi,
-            skip_tool_panel_section_name=False
+            skip_tool_panel_section_name=False,
+            get_data_managers=True
         )
         repository_list = get_repository_list.tool_list
         repositories = repository_list['tools']

--- a/ephemeris/shed_tools.py
+++ b/ephemeris/shed_tools.py
@@ -40,7 +40,6 @@ import sys
 import time
 from argparse import ArgumentParser
 
-import yaml
 from bioblend.galaxy.client import ConnectionError
 from bioblend.galaxy.toolshed import ToolShedClient
 from bioblend.toolshed import ToolShedInstance
@@ -489,7 +488,7 @@ def get_install_repository_manager(options):
         install_tool_dependencies = repository_list.get(
             'install_tool_dependencies', INSTALL_TOOL_DEPENDENCIES)
     elif options.tool_yaml:
-        repositories = [yaml.load(options.tool_yaml)]
+        repositories = load_yaml_file(options.tool_yaml)
     elif options.update_tools:
         get_repository_list = GiToToolYaml(
             gi=gi,

--- a/scripts/test_wheel.bash
+++ b/scripts/test_wheel.bash
@@ -16,7 +16,7 @@ DEV_REQUIREMENTS="${PROJECT_DIRECTORY}/dev-requirements.txt"
 cd $PROJECT_DIRECTORY
 
 
-WORKING_DIRECTORY=`mktemp -d -t testXXXXXX`
+WORKING_DIRECTORY=$(mktemp -d -t testXXXXXX)
 cp -r "$PROJECT_DIRECTORY"/{.coveragerc,setup.cfg,tests,project_templates} "$WORKING_DIRECTORY"
 
 cd "$WORKING_DIRECTORY"

--- a/tests/test.sh
+++ b/tests/test.sh
@@ -73,6 +73,16 @@ shed-tools install -t "$TEST_DATA"/tool_list.yaml.sample -a admin -g http://loca
 get-tool-list -g http://localhost:$WEB_PORT -o result_tool_list_post.yaml
 grep 4d82cf59895e result_tool_list_post.yaml && grep 0b4e36026794 result_tool_list_post.yaml  # this means both revisions have been successfully installed.
 
+# Test whether get-tool-list is able to fetch data managers
+echo "get-tool-list should not return data managers"
+get-tool-list -g http://localhost:$WEB_PORT -o result_tool_list_post.yaml
+grep -v data_manager_sam_fasta_index_builder result_tool_list_post.yaml
+echo "get-tool-list with an api key should not return data managers"
+get-tool-list -g http://localhost:$WEB_PORT -a admin -o result_tool_list_post.yaml
+grep -v data_manager_sam_fasta_index_builder result_tool_list_post.yaml
+echo "get-tool-list with an api_key and --get_data_mangers should return data managers"
+get-tool-list -g http://localhost:$WEB_PORT -a admin --get_data_managers -o result_tool_list_post.yaml
+grep data_manager_sam_fasta_index_builder result_tool_list_post.yaml
 
 
 echo "Wait a few seconds before restarting galaxy"

--- a/tests/test.sh
+++ b/tests/test.sh
@@ -19,9 +19,9 @@ function start_container {
     # We start the image with the -P flag that published all exposed container ports
     # to random free ports on the host, since on OS X the container can't be reached
     # through the internal network (https://docs.docker.com/docker-for-mac/networking/#i-cannot-ping-my-containers)
-    CID=`docker run -d -e GALAXY_CONFIG_WATCH_TOOL_DATA_DIR=True -P bgruening/galaxy-stable`
+    CID=$(docker run -d -e GALAXY_CONFIG_WATCH_TOOL_DATA_DIR=True -P bgruening/galaxy-stable)
     # We get the webport (https://docs.docker.com/engine/reference/commandline/inspect/#list-all-port-bindings)
-    WEB_PORT=`docker inspect --format="{{(index (index .NetworkSettings.Ports \"$INTERNAL_EXPOSED_WEB_PORT/tcp\") 0).HostPort}}" $CID`
+    WEB_PORT=$(docker inspect --format="{{(index (index .NetworkSettings.Ports \"$INTERNAL_EXPOSED_WEB_PORT/tcp\") 0).HostPort}}" $CID)
     echo "Wait for galaxy to start"
     galaxy-wait -g http://localhost:$WEB_PORT -v --timeout 120
 }
@@ -124,7 +124,7 @@ run-data-managers -a admin -g http://localhost:$WEB_PORT --config "$TEST_DATA"/r
 cat data_manager_output.txt
 
 echo "Number of skipped jobs should be 6"
-data_manager_already_installed=$(cat data_manager_output.txt | grep -i "Skipped jobs: 6" -c)
+data_manager_already_installed=$(grep -i "Skipped jobs: 6" -c data_manager_output.txt)
 if [ $data_manager_already_installed -ne 1 ]
     then
         echo "ERROR: Not all already installed genomes were skipped"


### PR DESCRIPTION
Hi. This solves #69 .
Have not run extensive testing yet, but will do that tomorrow.
It seems to run for now. Curious to see your feedback.

One of the side effects is that `get-tool-list` now also uses `get_galaxy_connection` method. a nice step towards unifying ephemeris.

EDIT:
Changes:
- `shed-tools update` now also updates data managers.
- With `get-tool-list` you can now also get all installed data managers, provided you have admin access to the galaxy.