### PR TITLE
Run data managers aggressive parallelization and refactoring.

### DIFF
--- a/ephemeris/run_data_managers.py
+++ b/ephemeris/run_data_managers.py
@@ -229,12 +229,12 @@ class DataManagers:
             job_list = []
             for skipped_job in skipped_jobs:
                 if overwrite:
-                    log.info('%s already run for %s. Skipping.' % (skipped_job["tool_id"], skipped_job["inputs"]))
-                    all_skipped_jobs.append(skipped_job)
-                else:
                     log.info('%s already run for %s. Entry will be overwritten.' %
                              (skipped_job["tool_id"], skipped_job["inputs"]))
                     jobs.append(skipped_job)
+                else:
+                    log.info('%s already run for %s. Skipping.' % (skipped_job["tool_id"], skipped_job["inputs"]))
+                    all_skipped_jobs.append(skipped_job)
             for job in jobs:
                 started_job = self.gi.tools.run_tool(history_id=None, tool_id=job["tool_id"], tool_inputs=job["inputs"])
                 log.info('Dispatched job %i. Running DM: "%s" with parameters: %s' %

--- a/ephemeris/run_data_managers.py
+++ b/ephemeris/run_data_managers.py
@@ -75,41 +75,48 @@ def wait(gi, job_list):
             time.sleep(30)
     return successful_jobs, failed_jobs
 
+class DataManagers:
+    def __init__(self,galaxy_instance,configuration,log,overwrite=False,ignore_errors=False):
+        self.gi = galaxy_instance
+        self.config = configuration
+        self.log = log
+        self.overwrite = overwrite
+        self.ignore_erros = ignore_errors
+        self.tool_data_client = ToolDataClient(self.gi)
+        # In order of importance!
+        self.possible_name_keys = ['name', 'sequence_name']
 
-def data_table_entry_exists(tool_data_client, data_table_name, entry, column='value'):
-    '''Checks whether an entry exists in the a specified column in the data_table.'''
-    try:
-        data_table_content = tool_data_client.show_data_table(data_table_name)
-    except Exception:
-        raise Exception('Table "%s" does not exist' % (data_table_name))
+    def data_table_entry_exists(self, data_table_name, entry, column='value'):
+        '''Checks whether an entry exists in the a specified column in the data_table.'''
+        try:
+            data_table_content = self.tool_data_client.show_data_table(data_table_name)
+        except Exception:
+            raise Exception('Table "%s" does not exist' % (data_table_name))
 
-    try:
-        column_index = data_table_content.get('columns').index(column)
-    except IndexError:
-        raise IndexError('Column "%s" does not exist in %s' % (column, data_table_name))
+        try:
+            column_index = data_table_content.get('columns').index(column)
+        except IndexError:
+            raise IndexError('Column "%s" does not exist in %s' % (column, data_table_name))
 
-    for field in data_table_content.get('fields'):
-        if field[column_index] == entry:
-            return True
-    return False
+        for field in data_table_content.get('fields'):
+            if field[column_index] == entry:
+                return True
+        return False
 
+    def get_name_from_inputs(self,input_dict):
+        '''Returns the value that will most likely be recorded in the "name" column of the datatable. Or returns False'''
+        for key in self.possible_name_keys:
+            if key in input_dict:
+                return input_dict.get(key)
+        return False
 
-def get_name_from_inputs(input_dict):
-    '''Returns the value that will most likely be recorded in the "name" column of the datatable. Or returns False'''
-    possible_keys = ['name', 'sequence_name']  # In order of importance!
-    for key in possible_keys:
-        if key in input_dict:
-            return input_dict.get(key)
-    return False
-
-
-def get_value_from_inputs(input_dict):
-    '''Returns the value that will most likely be recorded in the "value" column of the datatable. Or returns False'''
-    possible_keys = ['value', 'sequence_id', 'dbkey']  # In order of importance!
-    for key in possible_keys:
-        if key in input_dict:
-            return input_dict.get(key)
-    return False
+    def get_value_from_inputs(self,input_dict):
+        '''Returns the value that will most likely be recorded in the "value" column of the datatable. Or returns False'''
+        possible_keys = ['value', 'sequence_id', 'dbkey']  # In order of importance!
+        for key in possible_keys:
+            if key in input_dict:
+                return input_dict.get(key)
+        return False
 
 
 def input_entries_exist_in_data_tables(tool_data_client, data_tables, input_dict):

--- a/ephemeris/run_data_managers.py
+++ b/ephemeris/run_data_managers.py
@@ -237,7 +237,8 @@ class DataManagers:
                     jobs.append(skipped_job)
             for job in jobs:
                 started_job = self.gi.tools.run_tool(history_id=None, tool_id=job["tool_id"], tool_inputs=job["inputs"])
-                log.info('Dispatched job %i. Running DM: "%s" with parameters: %s' % (started_job['outputs'][0]['hid'], job["tool_id"], job["inputs"]))
+                log.info('Dispatched job %i. Running DM: "%s" with parameters: %s' %
+                         (started_job['outputs'][0]['hid'], job["tool_id"], job["inputs"]))
                 job_list.append(started_job)
 
             successful_jobs, failed_jobs = wait(self.gi, job_list, log)

--- a/ephemeris/run_data_managers.py
+++ b/ephemeris/run_data_managers.py
@@ -215,8 +215,8 @@ class DataManagers:
                              (skipped_job["tool_id"], skipped_job["inputs"]))
                     jobs.append(skipped_job)
             for job in jobs:
-                started_job = self.gi.tools.run_tool(history_id=None, tool_id=job["tool_id"], tool_inputs=job["tool_inputs"])
-                log.info('Dispatched job %i. Running DM: "%s" with parameters: %s' % (job['outputs'][0]['hid'], job["tool_id"], job["tool_inputs"]))
+                started_job = self.gi.tools.run_tool(history_id=None, tool_id=job["tool_id"], tool_inputs=job["inputs"])
+                log.info('Dispatched job %i. Running DM: "%s" with parameters: %s' % (started_job['outputs'][0]['hid'], job["tool_id"], job["inputs"]))
                 job_list.append(started_job)
 
             successful_jobs, failed_jobs = wait(self.gi, job_list, log)

--- a/ephemeris/run_data_managers.py
+++ b/ephemeris/run_data_managers.py
@@ -37,7 +37,7 @@ from .ephemeris_log import disable_external_library_logging, setup_global_logger
 
 
 DEFAULT_URL = "http://localhost"
-DEFAULT_SOURCE_TABLES = ["all_fasta", "gemini_databases"]
+DEFAULT_SOURCE_TABLES = ["all_fasta"]
 
 
 def wait(gi, job_list, log):

--- a/tests/data_manager_list.yaml
+++ b/tests/data_manager_list.yaml
@@ -1,0 +1,7 @@
+# This is just a sample file. For a fully documented version of this file, see
+# https://github.com/galaxyproject/ansible-galaxy-tools/blob/master/files/tool_list.yaml.sample
+tools:
+- name: data_manager_fetch_genome_dbkeys_all_fasta
+  owner: devteam
+- name: data_manager_sam_fasta_index_builder
+  owner: devteam

--- a/tests/data_manager_list.yaml
+++ b/tests/data_manager_list.yaml
@@ -5,3 +5,6 @@ tools:
   owner: devteam
 - name: data_manager_sam_fasta_index_builder
   owner: devteam
+- name: data_manager_bwa_mem_index_builder
+  owner: devteam
+

--- a/tests/run_data_managers.yaml.test
+++ b/tests/run_data_managers.yaml.test
@@ -11,7 +11,7 @@ genomes:
       id: NoroVirCHA7A011
 
 data_managers:
-    - id: toolshed.g2.bx.psu.edu/repos/devteam/data_manager_fetch_genome_dbkeys_all_fasta/data_manager_fetch_genome_all_fasta_dbkey/0.0.2
+    - id: data_manager_fetch_genome_all_fasta_dbkey
       params:
         - 'dbkey_source|dbkey_source_selector': 'new'
         - 'dbkey_source|dbkey': '{{ item.id }}'
@@ -33,3 +33,12 @@ data_managers:
       items: "{{ genomes }}"
       data_table_reload:
         - fasta_indexes
+
+    - id: bwa_mem_index_builder_data_manager
+      params:
+        - 'all_fasta_source': '{{ item.id }}'
+        - 'sequence_name': '{{ item.name }}'
+        - 'sequence_id': '{{ item.id }}'
+      items: "{{ genomes }}"
+      data_table_reload:
+        - bwa_mem_indexes

--- a/tests/test.sh
+++ b/tests/test.sh
@@ -3,10 +3,9 @@
 set -eu
 set -o pipefail
 
-CURRENT_DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"
-TEST_DATA=${EPHEMERIS_TEST_DATA:-"$CURRENT_DIR"}
-# The exposed web port may change to 443 in the future
-INTERNAL_EXPOSED_WEB_PORT=80
+SCRIPT_DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"
+
+source $SCRIPT_DIR/test_library.sh
 
 run-data-managers --help
 shed-tools install --help
@@ -15,121 +14,9 @@ workflow-install --help
 setup-data-libraries --help
 get-tool-list --help
 
-function start_container {
-    # We start the image with the -P flag that published all exposed container ports
-    # to random free ports on the host, since on OS X the container can't be reached
-    # through the internal network (https://docs.docker.com/docker-for-mac/networking/#i-cannot-ping-my-containers)
-    CID=$(docker run -d -e GALAXY_CONFIG_WATCH_TOOL_DATA_DIR=True -P bgruening/galaxy-stable)
-    # We get the webport (https://docs.docker.com/engine/reference/commandline/inspect/#list-all-port-bindings)
-    WEB_PORT=$(docker inspect --format="{{(index (index .NetworkSettings.Ports \"$INTERNAL_EXPOSED_WEB_PORT/tcp\") 0).HostPort}}" $CID)
-    echo "Wait for galaxy to start"
-    galaxy-wait -g http://localhost:$WEB_PORT -v --timeout 120
-}
-
-function start_new_container {
-    echo "Start new container"
-    docker rm -f $CID
-    start_container
-}
-
-echo "Starting galaxy docker container"
-start_container
-docker ps
-
-echo "Check tool installation with yaml on the commandline"
-# CD Hit was chosen since it is old and seems to be unmaintained. Last update was 2015.
-# Anyone know a smaller tool that could fit its place?
-OLD_TOOL="{'owner':'jjohnson','name':'cdhit','revisions':['34a799d173f7'],'tool_panel_section_label':'CD_HIT'}"
-shed-tools install -y  ${OLD_TOOL} --user admin@galaxy.org -p admin -g http://localhost:$WEB_PORT
-get-tool-list -g http://localhost:$WEB_PORT -o result_tool_list.yaml
-grep "cdhit" result_tool_list.yaml
-grep "34a799d173f7" result_tool_list.yaml #installed revision
-
-echo "Check update function"
-shed-tools update -a admin -g http://localhost:$WEB_PORT
-get-tool-list -g http://localhost:$WEB_PORT -o result_tool_list.yaml
-grep "cdhit" result_tool_list.yaml
-grep "28b7a43907f0" result_tool_list.yaml #latest revision
-
-start_new_container
-echo "Check tool installation with command line flags"
-shed-tools install --name cdhit --owner jjohnson --section_label "CD_HIT" --revisions 34a799d173f7 -a admin -g http://localhost:$WEB_PORT
-get-tool-list -g http://localhost:$WEB_PORT -o result_tool_list.yaml
-grep "cdhit" result_tool_list.yaml
-grep "34a799d173f7" result_tool_list.yaml #installed revision
-
-start_new_container
-echo "Check tool installation with --latest"
-shed-tools install -y  $OLD_TOOL --user admin@galaxy.org -p admin -g http://localhost:$WEB_PORT --latest
-get-tool-list -g http://localhost:$WEB_PORT -o result_tool_list.yaml
-grep "cdhit" result_tool_list.yaml
-grep "28b7a43907f0" result_tool_list.yaml #latest revision
-
-start_new_container
-echo "Check tool installation from tool list"
-# Establish the current tool list
-get-tool-list -g http://localhost:$WEB_PORT -o result_tool_list_pre.yaml
-shed-tools install -t "$TEST_DATA"/tool_list.yaml.sample -a admin -g http://localhost:$WEB_PORT
-get-tool-list -g http://localhost:$WEB_PORT -o result_tool_list_post.yaml
-grep 4d82cf59895e result_tool_list_post.yaml && grep 0b4e36026794 result_tool_list_post.yaml  # this means both revisions have been successfully installed.
-
-# Test whether get-tool-list is able to fetch data managers
-echo "get-tool-list should not return data managers"
-get-tool-list -g http://localhost:$WEB_PORT -o result_tool_list_post.yaml
-grep -v data_manager_sam_fasta_index_builder result_tool_list_post.yaml
-echo "get-tool-list with an api key should not return data managers"
-get-tool-list -g http://localhost:$WEB_PORT -a admin -o result_tool_list_post.yaml
-grep -v data_manager_sam_fasta_index_builder result_tool_list_post.yaml
-echo "get-tool-list with an api_key and --get_data_mangers should return data managers"
-get-tool-list -g http://localhost:$WEB_PORT -a admin --get_data_managers -o result_tool_list_post.yaml
-grep data_manager_sam_fasta_index_builder result_tool_list_post.yaml
-
-
-echo "Wait a few seconds before restarting galaxy"
-sleep 15
-
-echo "Restarting galaxy"
-#We restart galaxy because otherwise the data manager tables won't be watched
-docker exec $CID supervisorctl restart galaxy:
-
-echo "Wait for galaxy to start"
-galaxy-wait -g http://localhost:$WEB_PORT -v --timeout 120
-
-echo "Check workflow installation"
-workflow-install --user admin@galaxy.org -p admin -g http://localhost:$WEB_PORT -w "$TEST_DATA"/test_workflow.ga
-workflow-install -a admin -g http://localhost:$WEB_PORT -w "$TEST_DATA"/test_workflow.ga
-
-echo "Populate data libraries"
-setup-data-libraries --user admin@galaxy.org -p admin -g http://localhost:$WEB_PORT -i "$TEST_DATA"/library_data_example.yaml
-setup-data-libraries -a admin -g http://localhost:$WEB_PORT -i "$TEST_DATA"/library_data_example.yaml
-
-echo "Get tool list from Galaxy"
-get-tool-list -g http://localhost:$WEB_PORT -o result_tool_list.yaml
-workflow-to-tools -w "$TEST_DATA"/test_workflow_2.ga -o result_workflow_to_tools.yaml
-
-echo "Check tool installation from workflow"
-shed-tools install -t result_workflow_to_tools.yaml -a admin -g http://localhost:$WEB_PORT
-shed-tools install -t result_workflow_to_tools.yaml --user admin@galaxy.org -p admin -g http://localhost:$WEB_PORT
-
-echo "Check installation of reference genomes"
-run-data-managers --user admin@galaxy.org -p admin -g http://localhost:$WEB_PORT --config "$TEST_DATA"/run_data_managers.yaml.test
-
-echo "Small waiting step to allow data-tables to update"
-# This seems to be necessary on travis
-sleep 15
-
-echo "Check if installation is skipped when reference genomes are already installed."
-run-data-managers -a admin -g http://localhost:$WEB_PORT --config "$TEST_DATA"/run_data_managers.yaml.test &> data_manager_output.txt
-# Check if already installed was thrown
-cat data_manager_output.txt
-
-echo "Number of skipped jobs should be 6"
-data_manager_already_installed=$(grep -i "Skipped jobs: 6" -c data_manager_output.txt)
-if [ $data_manager_already_installed -ne 1 ]
-    then
-        echo "ERROR: Not all already installed genomes were skipped"
-        exit 1
-fi
+source $TEST_DATA/test_shed_tools.sh
+source $TEST_DATA/test_workflow_and_data.sh
+source $TEST_DATA/test_run_data_managers.sh
 
 # Remove running container
 docker rm -f $CID

--- a/tests/test.sh
+++ b/tests/test.sh
@@ -18,5 +18,3 @@ source $TEST_DATA/test_shed_tools.sh
 source $TEST_DATA/test_workflow_and_data.sh
 source $TEST_DATA/test_run_data_managers.sh
 
-# Remove running container
-docker rm -f $CID

--- a/tests/test_library.sh
+++ b/tests/test_library.sh
@@ -1,0 +1,27 @@
+#!/usr/bin/env bash
+
+set -eu
+set -o pipefail
+
+CURRENT_DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"
+TEST_DATA=${EPHEMERIS_TEST_DATA:-"$CURRENT_DIR"}
+# The exposed web port may change to 443 in the future
+INTERNAL_EXPOSED_WEB_PORT=80
+
+
+function start_container {
+    # We start the image with the -P flag that published all exposed container ports
+    # to random free ports on the host, since on OS X the container can't be reached
+    # through the internal network (https://docs.docker.com/docker-for-mac/networking/#i-cannot-ping-my-containers)
+    CID=$(docker run -d -e GALAXY_CONFIG_WATCH_TOOL_DATA_DIR=True -P bgruening/galaxy-stable)
+    # We get the webport (https://docs.docker.com/engine/reference/commandline/inspect/#list-all-port-bindings)
+    WEB_PORT=$(docker inspect --format="{{(index (index .NetworkSettings.Ports \"$INTERNAL_EXPOSED_WEB_PORT/tcp\") 0).HostPort}}" $CID)
+    echo "Wait for galaxy to start"
+    galaxy-wait -g http://localhost:$WEB_PORT -v --timeout 120
+}
+
+function start_new_container {
+    echo "Start new container"
+    docker rm -f $CID
+    start_container
+}

--- a/tests/test_library.sh
+++ b/tests/test_library.sh
@@ -4,7 +4,7 @@ set -eu
 set -o pipefail
 
 CURRENT_DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"
-TEST_DATA=${EPHEMERIS_TEST_DATA:-"$CURRENT_DIR"}
+export TEST_DATA=${EPHEMERIS_TEST_DATA:-"$CURRENT_DIR"}
 # The exposed web port may change to 443 in the future
 INTERNAL_EXPOSED_WEB_PORT=80
 

--- a/tests/test_run_data_managers.sh
+++ b/tests/test_run_data_managers.sh
@@ -17,13 +17,13 @@ shed-tools install -t "$TEST_DATA"/data_manager_list.yaml -a admin -g http://loc
 # Test whether get-tool-list is able to fetch data managers
 echo "get-tool-list should not return data managers"
 get-tool-list -g http://localhost:$WEB_PORT -o result_tool_list_post.yaml
-grep -v data_manager_sam_fasta_index_builder result_tool_list_post.yaml
+grep -v data_manager result_tool_list_post.yaml
 echo "get-tool-list with an api key should not return data managers"
 get-tool-list -g http://localhost:$WEB_PORT -a admin -o result_tool_list_post.yaml
-grep -v data_manager_sam_fasta_index_builder result_tool_list_post.yaml
+grep -v data_manager result_tool_list_post.yaml
 echo "get-tool-list with an api_key and --get_data_mangers should return data managers"
 get-tool-list -g http://localhost:$WEB_PORT -a admin --get_data_managers -o result_tool_list_post.yaml
-grep data_manager_sam_fasta_index_builder result_tool_list_post.yaml
+grep data_manager result_tool_list_post.yaml
 
 echo "Wait a few seconds before restarting galaxy"
 sleep 15
@@ -38,6 +38,8 @@ galaxy-wait -g http://localhost:$WEB_PORT -v --timeout 120
 echo "Check installation of reference genomes"
 run-data-managers --user admin@galaxy.org -p admin -g http://localhost:$WEB_PORT --config "$TEST_DATA"/run_data_managers.yaml.test
 
+#TODO: Implement test whether the indexers where launched simeltaneously
+
 echo "Small waiting step to allow data-tables to update"
 # This seems to be necessary on travis
 sleep 15
@@ -47,8 +49,8 @@ run-data-managers -a admin -g http://localhost:$WEB_PORT --config "$TEST_DATA"/r
 # Check if already installed was thrown
 cat data_manager_output.txt
 
-echo "Number of skipped jobs should be 6"
-data_manager_already_installed=$(grep -i "Skipped jobs: 6" -c data_manager_output.txt)
+echo "Number of skipped jobs should be 9"
+data_manager_already_installed=$(grep -i "Skipped jobs: 9" -c data_manager_output.txt)
 if [ $data_manager_already_installed -ne 1 ]
     then
         echo "ERROR: Not all already installed genomes were skipped"

--- a/tests/test_run_data_managers.sh
+++ b/tests/test_run_data_managers.sh
@@ -1,0 +1,58 @@
+#!/usr/bin/env bash
+
+set -eu
+set -o pipefail
+
+SCRIPT_DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"
+
+source $SCRIPT_DIR/test_library.sh
+
+echo "Starting galaxy docker container"
+start_container
+docker ps
+
+echo "Installing data managers"
+shed-tools install -t "$TEST_DATA"/data_manager_list.yaml -a admin -g http://localhost:$WEB_PORT
+
+# Test whether get-tool-list is able to fetch data managers
+echo "get-tool-list should not return data managers"
+get-tool-list -g http://localhost:$WEB_PORT -o result_tool_list_post.yaml
+grep -v data_manager_sam_fasta_index_builder result_tool_list_post.yaml
+echo "get-tool-list with an api key should not return data managers"
+get-tool-list -g http://localhost:$WEB_PORT -a admin -o result_tool_list_post.yaml
+grep -v data_manager_sam_fasta_index_builder result_tool_list_post.yaml
+echo "get-tool-list with an api_key and --get_data_mangers should return data managers"
+get-tool-list -g http://localhost:$WEB_PORT -a admin --get_data_managers -o result_tool_list_post.yaml
+grep data_manager_sam_fasta_index_builder result_tool_list_post.yaml
+
+echo "Wait a few seconds before restarting galaxy"
+sleep 15
+
+echo "Restarting galaxy"
+#We restart galaxy because otherwise the data manager tables won't be watched
+docker exec $CID supervisorctl restart galaxy:
+
+echo "Wait for galaxy to start"
+galaxy-wait -g http://localhost:$WEB_PORT -v --timeout 120
+
+echo "Check installation of reference genomes"
+run-data-managers --user admin@galaxy.org -p admin -g http://localhost:$WEB_PORT --config "$TEST_DATA"/run_data_managers.yaml.test
+
+echo "Small waiting step to allow data-tables to update"
+# This seems to be necessary on travis
+sleep 15
+
+echo "Check if installation is skipped when reference genomes are already installed."
+run-data-managers -a admin -g http://localhost:$WEB_PORT --config "$TEST_DATA"/run_data_managers.yaml.test &> data_manager_output.txt
+# Check if already installed was thrown
+cat data_manager_output.txt
+
+echo "Number of skipped jobs should be 6"
+data_manager_already_installed=$(grep -i "Skipped jobs: 6" -c data_manager_output.txt)
+if [ $data_manager_already_installed -ne 1 ]
+    then
+        echo "ERROR: Not all already installed genomes were skipped"
+        exit 1
+fi
+
+docker rm -f $CID

--- a/tests/test_shed_tools.sh
+++ b/tests/test_shed_tools.sh
@@ -1,0 +1,50 @@
+#!/usr/bin/env bash
+
+set -eu
+set -o pipefail
+
+SCRIPT_DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"
+
+source $SCRIPT_DIR/test_library.sh
+echo "Starting galaxy docker container"
+start_container
+docker ps
+
+echo "Check tool installation with yaml on the commandline"
+# CD Hit was chosen since it is old and seems to be unmaintained. Last update was 2015.
+# Anyone know a smaller tool that could fit its place?
+OLD_TOOL="{'owner':'jjohnson','name':'cdhit','revisions':['34a799d173f7'],'tool_panel_section_label':'CD_HIT'}"
+shed-tools install -y  ${OLD_TOOL} --user admin@galaxy.org -p admin -g http://localhost:$WEB_PORT
+get-tool-list -g http://localhost:$WEB_PORT -o result_tool_list.yaml
+grep "cdhit" result_tool_list.yaml
+grep "34a799d173f7" result_tool_list.yaml #installed revision
+
+echo "Check update function"
+shed-tools update -a admin -g http://localhost:$WEB_PORT
+get-tool-list -g http://localhost:$WEB_PORT -o result_tool_list.yaml
+grep "cdhit" result_tool_list.yaml
+grep "28b7a43907f0" result_tool_list.yaml #latest revision
+
+start_new_container
+echo "Check tool installation with command line flags"
+shed-tools install --name cdhit --owner jjohnson --section_label "CD_HIT" --revisions 34a799d173f7 -a admin -g http://localhost:$WEB_PORT
+get-tool-list -g http://localhost:$WEB_PORT -o result_tool_list.yaml
+grep "cdhit" result_tool_list.yaml
+grep "34a799d173f7" result_tool_list.yaml #installed revision
+
+start_new_container
+echo "Check tool installation with --latest"
+shed-tools install -y  $OLD_TOOL --user admin@galaxy.org -p admin -g http://localhost:$WEB_PORT --latest
+get-tool-list -g http://localhost:$WEB_PORT -o result_tool_list.yaml
+grep "cdhit" result_tool_list.yaml
+grep "28b7a43907f0" result_tool_list.yaml #latest revision
+
+start_new_container
+echo "Check tool installation from tool list"
+# Establish the current tool list
+get-tool-list -g http://localhost:$WEB_PORT -o result_tool_list_pre.yaml
+shed-tools install -t "$TEST_DATA"/tool_list.yaml.sample -a admin -g http://localhost:$WEB_PORT
+get-tool-list -g http://localhost:$WEB_PORT -o result_tool_list_post.yaml
+grep 4d82cf59895e result_tool_list_post.yaml && grep 0b4e36026794 result_tool_list_post.yaml  # this means both revisions have been successfully installed.
+
+docker rm -f $CID

--- a/tests/test_workflow_and_data.sh
+++ b/tests/test_workflow_and_data.sh
@@ -1,0 +1,30 @@
+#!/usr/bin/env bash
+
+set -eu
+set -o pipefail
+
+SCRIPT_DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"
+
+source $SCRIPT_DIR/test_library.sh
+
+echo "Starting galaxy docker container"
+start_container
+docker ps
+
+echo "Check workflow installation"
+workflow-install --user admin@galaxy.org -p admin -g http://localhost:$WEB_PORT -w "$TEST_DATA"/test_workflow.ga
+workflow-install -a admin -g http://localhost:$WEB_PORT -w "$TEST_DATA"/test_workflow.ga
+
+echo "Populate data libraries"
+setup-data-libraries --user admin@galaxy.org -p admin -g http://localhost:$WEB_PORT -i "$TEST_DATA"/library_data_example.yaml
+setup-data-libraries -a admin -g http://localhost:$WEB_PORT -i "$TEST_DATA"/library_data_example.yaml
+
+echo "Get tool list from Galaxy"
+get-tool-list -g http://localhost:$WEB_PORT -o result_tool_list.yaml
+workflow-to-tools -w "$TEST_DATA"/test_workflow_2.ga -o result_workflow_to_tools.yaml
+
+echo "Check tool installation from workflow"
+shed-tools install -t result_workflow_to_tools.yaml -a admin -g http://localhost:$WEB_PORT
+shed-tools install -t result_workflow_to_tools.yaml --user admin@galaxy.org -p admin -g http://localhost:$WEB_PORT
+
+docker rm -f $CID

--- a/tests/tool_list.yaml.sample
+++ b/tests/tool_list.yaml.sample
@@ -16,7 +16,4 @@ tools:
   tool_panel_section_label: 'New Converters'
   revisions:
   - '0b4e36026794'  # v1.1.0
-- name: data_manager_fetch_genome_dbkeys_all_fasta
-  owner: devteam
-- name: data_manager_sam_fasta_index_builder
-  owner: devteam
+


### PR DESCRIPTION
- [x] TODO: Rebase on master once #78 is pulled. I iterated on this branch because it had some improvements and I wanted to avoid merge conflicts.

While installing a few reference genomes on my galaxy I got annoyed by the indexing steps. These take quite a long time. And `run-data-managers` only runs one data manager at a time. I feel that job scheduling should be handled by Galaxy and not by `run-data-managers` so I changed the way that `run-data-managers` submits jobs.

Now `run-data-managers` first picks all the data managers that populate source tables (DEFAULT: ["all_fasta"]). Since other data managers depend on these tables. Then it runs them. After that it runs _all_ the other data managers. Let galaxy figure out to schedule all these jobs. 
This provides a significant speedup when you're adding a vertebrate genome to the list. Instead of watching your bowtie and bwa indexes be created one after another, they are now created simultaneously.

Internally I had to completely overhaul `run-data-managers`. It is a now a `DataManagers` object that has a run method. This made a lot of interfunction communication much easier. Also the code is a bit cleaner now. The DataManagers object can now also be used in other scripts.

Since I had to do some testing I overhauled the tests scripts as well. These are now split in 3 parts. The `shed-tools` testing was quite slow, and I did not want to wait on it all the time. There is now a separate script for testing `run-data-managers` which made testing a bit easier.