### PR TITLE
Option to test tools on update/install for Galaxy 18.05.

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -2,3 +2,5 @@ six>=1.9.0
 pyyaml
 bioblend>=0.10.0
 Jinja2
+galaxy-lib>=18.5.7
+


### PR DESCRIPTION
Builds on #78 from @rhpvorderman since it modifies similar files.

While it does run the tests and produce a JSON output file that should be usable with ``planemo test_reports`` (http://planemo.readthedocs.io/en/latest/commands.html#test-reports-command) after the next Planemo release, marked as WIP because:

- [x] The tool tests create a user and a user API key to run tool tests, this should be configurable.
- [x] It doesn't have any in-ephemeris reporting yet - not display of test results. What do people want to see here? Probably the JSON is not enough?
- [x] Probably we should break up timing code also and have separate timing for install and testing?
- [x] Failed tests don't modify the ``shed-tools`` exit code.
- [x] ~Do we want to do all the installs and then all the tests like this or should we try to interleave them or should we test as we install or should be make this configurable?~ Lets just stick with doing them at the end and leave things be for now - we can revisit in the future.

Also, what of these questions can we delay to a second iteration?

Implements https://github.com/galaxyproject/ephemeris/issues/76.
