### PR TITLE
Catch failures on requests to the installed repo list when doing post-timeout spinning on installation in shed-tools

### DIFF
--- a/ephemeris/shed_tools.py
+++ b/ephemeris/shed_tools.py
@@ -533,7 +533,11 @@ def wait_for_install(repository, tool_shed_client, timeout=3600):
     Returns True if install finished, returns False when timeout is exceeded.
     """
     def install_done(tool, tool_shed_client):
-        installed_repo_list = tool_shed_client.get_repositories()
+        try:
+            installed_repo_list = tool_shed_client.get_repositories()
+        except ConnectionError as e:
+            log.warning('Failed to get repositories list: %s', str(e))
+            return False
         for installing_repo in installed_repo_list:
             if (tool['name'] == installing_repo['name']) and (installing_repo['owner'] == tool['owner']):
                 if installing_repo['status'] not in ['Installed', 'Error']:


### PR DESCRIPTION
I was frequently getting stuff like this:

```pytb
(ephemeris)nate@weyerbacher% shed-tools install -t diffbind-upgrade.yaml -g https://test-installer.galaxyproject.org/ -v
Storing log file in: /tmp/ephemeris_pPBMw4
(1/1) Installing repository diffbind from bgruening to section "peak_calling" at revision c97a786e8fb5 (TRT: 0:00:58.435025)
Timeout during install of diffbind, extending wait to 1h
Traceback (most recent call last):
  File "/home/nate/.virtualenvs/ephemeris/bin/shed-tools", line 11, in <module>
    sys.exit(main())
  File "/home/nate/.virtualenvs/ephemeris/local/lib/python2.7/site-packages/ephemeris/shed_tools.py", line 937, in main
    install_tool_manager.install_repositories()
  File "/home/nate/.virtualenvs/ephemeris/local/lib/python2.7/site-packages/ephemeris/shed_tools.py", line 728, in install_repositories
    success = wait_for_install(repository=repository, tool_shed_client=self.tsc, timeout=3600)
  File "/home/nate/.virtualenvs/ephemeris/local/lib/python2.7/site-packages/ephemeris/shed_tools.py", line 543, in wait_for_install
    finished = install_done(repository, tool_shed_client)
  File "/home/nate/.virtualenvs/ephemeris/local/lib/python2.7/site-packages/ephemeris/shed_tools.py", line 536, in install_done
    installed_repo_list = tool_shed_client.get_repositories()
  File "/home/nate/.virtualenvs/ephemeris/local/lib/python2.7/site-packages/bioblend/galaxy/toolshed/__init__.py", line 36, in get_repositories
    return self._get()
  File "/home/nate/.virtualenvs/ephemeris/local/lib/python2.7/site-packages/bioblend/galaxy/client.py", line 128, in _get
    status_code=r.status_code)
bioblend.ConnectionError: GET: error 502: '<html>\r\n<head><title>502 Bad Gateway</title></head>\r\n<body bgcolor="white">\r\n<center><h1>502 Bad Gateway</h1></center>\r\n<hr><center>nginx/1.12.2</center>\r\n</body>\r\n</html>\r\n', 0 attempts left: <html>
<head><title>502 Bad Gateway</title></head>
<body bgcolor="white">
<center><h1>502 Bad Gateway</h1></center>
<hr><center>nginx/1.12.2</center>
</body>
</html>

(ephemeris)nate@weyerbacher%
```