### PR TITLE
fix coverage reporting on codacy

### DIFF
--- a/tox.ini
+++ b/tox.ini
@@ -41,9 +41,16 @@ commands = pytest {[tox]test_dir}
 
 [testenv:py35-pytest]
 passenv = TRAVIS,CODACY_PROJECT_TOKEN
+whitelist_externals = sed
+                      bash
 commands =
     pytest --cov={envsitepackagesdir}/ephemeris --cov-report xml {[tox]test_dir}
-    bash -c 'if [ "$TRAVIS" = "true" ] ; then python-codacy-coverage -r coverage.xml; fi'
+    # Replace the installed package directory by the source directory.
+    # This is needed for codacy to understand which files have coverage testing
+    sed -i 's#{envsitepackagesdir}#src#' coverage.xml
+    # If running on travis, send a coverage report to codacy.
+    # The CODACY_PROJECT_TOKEN env variable should be defined on travis.
+    bash -c 'if [ "$TRAVIS" = "true" ] ; then  python-codacy-coverage -r coverage.xml; fi'
 
 [testenv:py27]
 commands = bash {[tox]test_dir}/test.sh


### PR DESCRIPTION
Apparently the setup was not working. It appears that codacy needs to know the exact path of the source files for coverage to work. By contrast, coverage with pytest in a tox environment only works when the package site is used to determine coverage. 

Luckily `sed` can rescue us in this case.
I've tested this manually, and coverage reports are accepted now.