### PR TITLE
Fix  crash when tool_with_panel is empty

### DIFF
--- a/src/ephemeris/get_tool_list_from_galaxy.py
+++ b/src/ephemeris/get_tool_list_from_galaxy.py
@@ -114,11 +114,11 @@ class GiToToolYaml:
             # section labels and ids.
             # If someone knows a more effecient way around this problem it
             # will be greatly appreciated.
-            for repo in repos:
+            for repo in repos:                      
                 if not repo['deleted']:
+                    tool_panel_section_id = None
+                    tool_panel_section_label = None 
                     for repo_with_panel in tools_with_panel:
-                        tool_panel_section_id = None
-                        tool_panel_section_label = None
                         if the_same_repository(repo_with_panel, repo, check_revision=False):
                             tool_panel_section_id = repo_with_panel.get('tool_panel_section_id')
                             tool_panel_section_label = repo_with_panel.get('tool_panel_section_label')

--- a/src/ephemeris/get_tool_list_from_galaxy.py
+++ b/src/ephemeris/get_tool_list_from_galaxy.py
@@ -114,7 +114,7 @@ class GiToToolYaml:
             # section labels and ids.
             # If someone knows a more effecient way around this problem it
             # will be greatly appreciated.
-            for repo in repos:                      
+            for repo in repos:           
                 if not repo['deleted']:
                     tool_panel_section_id = None
                     tool_panel_section_label = None 


### PR DESCRIPTION
Before : Crash when 'tool_with_panel' is empty and ToolShedClient.get_repositories() is not. 
After : Define tool_panel_section_id/label outside of the for loop to remove the conditional definition dependency with 'tool_with_panel'