### PR TITLE
Fix crash when too_with_panel is empty

### DIFF
--- a/src/ephemeris/get_tool_list_from_galaxy.py
+++ b/src/ephemeris/get_tool_list_from_galaxy.py
@@ -116,9 +116,9 @@ class GiToToolYaml:
             # will be greatly appreciated.
             for repo in repos:
                 if not repo['deleted']:
+                    tool_panel_section_id = None
+                    tool_panel_section_label = None
                     for repo_with_panel in tools_with_panel:
-                        tool_panel_section_id = None
-                        tool_panel_section_label = None
                         if the_same_repository(repo_with_panel, repo, check_revision=False):
                             tool_panel_section_id = repo_with_panel.get('tool_panel_section_id')
                             tool_panel_section_label = repo_with_panel.get('tool_panel_section_label')


### PR DESCRIPTION
When tool_with_panel was empty and ToolSheedClient.get_repositories() was not it was crashing because tool_panel_section_id/label were not defined. Fix : Define them outside of the loop to match the use later inside the if condition.

Make a new branch/pull request because inside the other one there was a mysterious anoying sticky white space inserted.   