### PR TITLE
Update Docs for User Name (Should be Email)

### DIFF
--- a/src/ephemeris/common_parser.py
+++ b/src/ephemeris/common_parser.py
@@ -22,7 +22,7 @@ def get_common_args(login_required=True, log_file=False):
 
     if login_required:
         con_group.add_argument("-u", "--user",
-                               help="Galaxy user name")
+                               help="Galaxy user email address")
         con_group.add_argument("-p", "--password",
                                help="Password for the Galaxy user")
         con_group.add_argument("-a", "--api_key",


### PR DESCRIPTION
This tripped me up when trying to use the `shed-tools install` command. I entered `-u rdvelazquez` which is my public user name on the instance but the command failed. I had to enter `-u <my email address>` for the command to work.