### PR TITLE
fix default for 'parallel_tests' typo

### DIFF
--- a/src/ephemeris/shed_tools_args.py
+++ b/src/ephemeris/shed_tools_args.py
@@ -32,7 +32,7 @@ def parser():
         test_user="ephemeris@galaxyproject.org",
         test_json="tool_test_output.json",
         test_existing=False,
-        max_parallel_tests=1,
+        parallel_tests=1,
     )
 
     # SUBPARSERS


### PR DESCRIPTION
the `parallel_tests` also does not render in docs, not sure why yet