### PR TITLE
Fix default message check

### DIFF
--- a/src/ephemeris/shed_tools.py
+++ b/src/ephemeris/shed_tools.py
@@ -370,7 +370,7 @@ class InstallRepositoryManager(object):
                     log=log)
             return "installed"
         except (ConnectionError, requests.exceptions.ConnectionError) as e:
-            if default_err_msg in e.body:
+            if default_err_msg in str(e):
                 # THIS SHOULD NOT HAPPEN DUE TO THE CHECKS EARLIER
                 if log:
                     log.debug("\tRepository %s already installed (at revision %s)" %


### PR DESCRIPTION
requests.exceptions.ConnectionError Exceptions don't have a body
attribute, but bioblend's ConnectionError `__str__` includes
the body:
```
    def __str__(self):
        return "{0}: {1}".format(self.args[0], self.body)
```