### PR TITLE
Print exception when unexpected test failure is caught

### DIFF
--- a/src/ephemeris/shed_tools.py
+++ b/src/ephemeris/shed_tools.py
@@ -342,7 +342,7 @@ class InstallRepositoryManager(object):
                         log.info("Test '%s' passed", test_id)
                 except Exception as e:
                     if log:
-                        log.warning("Test '%s' failed", test_id)
+                        log.warning("Test '%s' failed", test_id, exc_info=True)
                     test_exceptions.append((test_id, e))
 
             executor.submit(run_test, test_index, test_id)


### PR DESCRIPTION
That was useful for figuring out
```
Test 'toolshed.g2.bx.psu.edu/repos/iuc/mothur_unifrac_weighted/mothur_unifrac_weighted/1.39.5.0-0' failed
Traceback (most recent call last):
  File "/var/jenkins/shiningpanda/jobs/35ce1600/virtualenvs/d41d8cd9/lib/python3.5/site-packages/ephemeris/shed_tools.py", line 338, in run_test
    register_job_data=register, quiet=True, test_history=test_history,
  File "/var/jenkins/shiningpanda/jobs/35ce1600/virtualenvs/d41d8cd9/lib/python3.5/site-packages/galaxy/tools/verify/interactor.py", line 733, in verify_tool
    stage_data_in_history(galaxy_interactor, tool_id, testdef.test_data(), history=test_history, force_path_paste=force_path_paste)
  File "/var/jenkins/shiningpanda/jobs/35ce1600/virtualenvs/d41d8cd9/lib/python3.5/site-packages/galaxy/tools/verify/interactor.py", line 86, in stage_data_in_history
    upload_wait()
  File "/var/jenkins/shiningpanda/jobs/35ce1600/virtualenvs/d41d8cd9/lib/python3.5/site-packages/galaxy/tools/verify/interactor.py", line 369, in <lambda>
    return lambda: self.wait_for_job(jobs[0]["id"], history_id, DEFAULT_TOOL_TEST_WAIT)
  File "/var/jenkins/shiningpanda/jobs/35ce1600/virtualenvs/d41d8cd9/lib/python3.5/site-packages/galaxy/tools/verify/interactor.py", line 238, in wait_for_job
    self.wait_for(lambda: not self.__job_ready(job_id, history_id), maxseconds=maxseconds)
  File "/var/jenkins/shiningpanda/jobs/35ce1600/virtualenvs/d41d8cd9/lib/python3.5/site-packages/galaxy/tools/verify/interactor.py", line 245, in wait_for
    while slept <= walltime_exceeded:
TypeError: unorderable types: int() <= str()
```