### PR TITLE
Fix `shed-tools test -t workflow_tools.yml`

### DIFF
--- a/src/ephemeris/generate_tool_list_from_ga_workflow_files.py
+++ b/src/ephemeris/generate_tool_list_from_ga_workflow_files.py
@@ -5,6 +5,8 @@ from argparse import ArgumentParser, RawDescriptionHelpFormatter
 
 import yaml
 
+from .shed_tools_methods import format_tool_shed_url
+
 INSTALL_TOOL_DEPENDENCIES = 'install_tool_dependencies: True'
 INSTALL_REPOSITORY_DEPENDENCIES = 'install_repository_dependencies: True'
 INSTALL_RESOLVER_DEPENDENCIES = 'install_resolver_dependencies: True'
@@ -57,8 +59,12 @@ def translate_workflow_dictionary_to_tool_list(tool_dictionary, panel_label):
             starting_tool_list.append(tsr)
     tool_list = []
     for tool in starting_tool_list:
-        sub_dic = {'name': tool['name'], 'owner': tool['owner'], 'revisions': [tool['changeset_revision']],
-                   'tool_panel_section_label': panel_label, 'tool_shed_url': 'https://' + tool['tool_shed']}
+        sub_dic = {
+            'name': tool['name'],
+            'owner': tool['owner'],
+            'revisions': [tool['changeset_revision']],
+            'tool_panel_section_label': panel_label,
+            'tool_shed_url': format_tool_shed_url(tool['tool_shed'])}
         tool_list.append(sub_dic)
     return tool_list
 

--- a/src/ephemeris/get_tool_list_from_galaxy.py
+++ b/src/ephemeris/get_tool_list_from_galaxy.py
@@ -11,6 +11,7 @@ from bioblend.galaxy.toolshed import ToolShedClient
 
 from . import get_galaxy_connection
 from .common_parser import get_common_args
+from .shed_tools_methods import format_tool_shed_url
 
 
 def get_tool_panel(gi):
@@ -33,7 +34,7 @@ def tools_for_repository(gi, repository):
         if tsr['name'] != name or tsr['owner'] != owner:
             return
 
-        if tool_shed_url and tsr['tool_shed'] != tool_shed_url:
+        if tool_shed_url and format_tool_shed_url(tsr['tool_shed']) != format_tool_shed_url(tool_shed_url):
             return
 
         if changeset_revision and changeset_revision != tsr["changeset_revision"]:


### PR DESCRIPTION
The `tool_shed` URLs returned by Galaxy via `get_tool_panel()` don't have a protocol part, while the `tool_shed_url` field in YAML files generated by `workflow-to-tools` start with an `https://` . This resulted in testing 0 tools when `shed_tools` is invoked on such a YAML file.