### PR TITLE
get all tools when searching for tool ids for testing (get_tools instead of get_tool_panel)

### DIFF
--- a/src/ephemeris/get_tool_list_from_galaxy.py
+++ b/src/ephemeris/get_tool_list_from_galaxy.py
@@ -19,7 +19,12 @@ def get_tool_panel(gi):
     return tool_client.get_tool_panel()
 
 
-def tools_for_repository(gi, repository):
+def get_tools(gi):
+    tool_client = ToolClient(gi)
+    return tool_client.get_tools()
+
+
+def tools_for_repository(gi, repository, all_tools=False):
     tool_shed_url = repository.get('tool_shed_url')
     name = repository['name']
     owner = repository['owner']
@@ -42,7 +47,8 @@ def tools_for_repository(gi, repository):
 
         tools.append(tool_elem)
 
-    walk_tools(get_tool_panel(gi), handle_tool)
+    elems = get_tools(gi) if changeset_revision and all_tools else get_tool_panel(gi)
+    walk_tools(elems, handle_tool)
 
     return tools
 

--- a/src/ephemeris/get_tool_list_from_galaxy.py
+++ b/src/ephemeris/get_tool_list_from_galaxy.py
@@ -47,7 +47,7 @@ def tools_for_repository(gi, repository, all_tools=False):
 
         tools.append(tool_elem)
 
-    elems = get_tools(gi) if changeset_revision and all_tools else get_tool_panel(gi)
+    elems = get_tools(gi) if changeset_revision or all_tools else get_tool_panel(gi)
     walk_tools(elems, handle_tool)
 
     return tools

--- a/src/ephemeris/shed_tools.py
+++ b/src/ephemeris/shed_tools.py
@@ -246,7 +246,7 @@ class InstallRepositoryManager(object):
 
         installed_tools = []
         for target_repository in target_repositories:
-            repo_tools = tools_for_repository(self.gi, target_repository)
+            repo_tools = tools_for_repository(self.gi, target_repository, all_tools=True)
             installed_tools.extend(repo_tools)
 
         all_test_results = []

--- a/src/ephemeris/shed_tools.py
+++ b/src/ephemeris/shed_tools.py
@@ -230,6 +230,7 @@ class InstallRepositoryManager(object):
                    test_user_api_key=None,
                    test_user="ephemeris@galaxyproject.org",
                    parallel_tests=1,
+                   test_all_versions=False,
                    ):
         """Run tool tests for all tools in each repository in supplied tool list or ``self.installed_repositories()``.
         """
@@ -246,7 +247,7 @@ class InstallRepositoryManager(object):
 
         installed_tools = []
         for target_repository in target_repositories:
-            repo_tools = tools_for_repository(self.gi, target_repository, all_tools=True)
+            repo_tools = tools_for_repository(self.gi, target_repository, all_tools=test_all_versions)
             installed_tools.extend(repo_tools)
 
         all_test_results = []
@@ -600,6 +601,7 @@ def main():
             test_user_api_key=args.test_user_api_key,
             test_user=args.test_user,
             parallel_tests=args.parallel_tests,
+            test_all_versions=args.test_all_versions,
         )
     else:
         raise NotImplementedError("This point in the code should not be reached. Please contact the developers.")

--- a/src/ephemeris/shed_tools_args.py
+++ b/src/ephemeris/shed_tools_args.py
@@ -232,5 +232,13 @@ def parser():
         type=int,
         help="Specify the maximum number of tests that will be run in parallel."
     )
+    test_command_parser.add_argument(
+        "--test_all_versions",
+        action="store_true",
+        dest="test_all_versions",
+        help="Run tests on all installed versions of tools.  This will only "
+             "apply for tools where revisions have not been provided through "
+             "the --revisions arg, --tool_file or --tool_yaml."
+    )
 
     return shed_parser


### PR DESCRIPTION
When shed-tools looks for tests, it looks for tool ids within the output of get_tool_panel.  There is generally only one version of a tool in the panel but there could be several versions of the tool installed.  I'd like to be able to run tests for older revisions of tools.  Currently if the --revisions arg does not correspond to the version in the panel, no tests are run.

My proposed change is to look in the output of get_tools instead of get_tool_panel if the revision is provided.

I'm not sure what should happen when there is no changeset revision - I've defaulted using get_tool_panel in this case to look for what is usually the most recent version, but I could change this so that it runs tests from all versions.

Catherine, Galaxy Australia