### PR TITLE
Various updates to testing and CI infrastructure.

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -12,6 +12,7 @@ jobs:
       matrix:
         python-version: ['3.6']
         tox-action:
+          - lint
           - pytest
           - integration
     services:

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -1,8 +1,5 @@
 name: Python CI
 on: [pull_request]
-env:
-  PGPASSWORD: postgres
-  PGHOST: localhost
 jobs:
   test:
     runs-on: ubuntu-latest
@@ -15,28 +12,13 @@ jobs:
           - lint
           - pytest
           - integration
-    services:
-      postgres:
-        image: postgres:10.8
-        env:
-          POSTGRES_USER: postgres
-          POSTGRES_PASSWORD: postgres
-          POSTGRES_DB: postgres
-        ports:
-        - 5432:5432
-        # needed because the postgres container does not provide a healthcheck
-        options: --health-cmd pg_isready --health-interval 10s --health-timeout 5s --health-retries 5
     steps:
       - uses: actions/checkout@v1
         with:
           fetch-depth: 1
-          submodules: true
       - uses: actions/setup-python@v1
         with:
           python-version: ${{ matrix.python-version }}
-      - name: Test psql
-        run: |
-          psql --tuples-only --username postgres -P pager=off --list
       - name: Install dependencies
         run: |
           python -m pip install --upgrade pip

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -13,7 +13,7 @@ jobs:
           - pytest
           - integration
     steps:
-      - uses: actions/checkout@v1
+      - uses: actions/checkout@v2
         with:
           fetch-depth: 1
       - uses: actions/setup-python@v1

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -1,0 +1,47 @@
+name: Python CI
+on: [pull_request]
+env:
+  PGPASSWORD: postgres
+  PGHOST: localhost
+jobs:
+  test:
+    runs-on: ubuntu-latest
+    timeout-minutes: 90
+    strategy:
+      fail-fast: false
+      matrix:
+        python-version: ['3.6']
+        tox-action:
+          - pytest
+          - integration
+    services:
+      postgres:
+        image: postgres:10.8
+        env:
+          POSTGRES_USER: postgres
+          POSTGRES_PASSWORD: postgres
+          POSTGRES_DB: postgres
+        ports:
+        - 5432:5432
+        # needed because the postgres container does not provide a healthcheck
+        options: --health-cmd pg_isready --health-interval 10s --health-timeout 5s --health-retries 5
+    steps:
+      - uses: actions/checkout@v1
+        with:
+          fetch-depth: 1
+          submodules: true
+      - uses: actions/setup-python@v1
+        with:
+          python-version: ${{ matrix.python-version }}
+      - name: Test psql
+        run: |
+          psql --tuples-only --username postgres -P pager=off --list
+      - name: Install dependencies
+        run: |
+          python -m pip install --upgrade pip
+          pip install tox coveralls
+      - name: Test with tox
+        run: |
+          TOXENV=$(echo $TOXENV | sed 's/\.//') tox
+        env:
+          TOXENV: py${{ matrix.python-version }}-${{ matrix.tox-action }}

--- a/.travis.yml
+++ b/.travis.yml
@@ -5,12 +5,8 @@ env:
     - secure: HwBDtauxcKJQccRk9fYtG90PNdB+KuNcDVY2MK4AVPLHoMCYGABIKJwUj+K9mcqc2wmYhWHfaufLJuMhr3X0FlPknM/aHdh16zUkIckje7WHqvyR2la1AIAMYaMpMikVJiexA6aElOW/aBuVnFolZyz9No+iq3bfF7iVvg2MLWopjMBsWGrHmAIReIVnPXy//Eka73pnwG2WdOjbKnrZfuUQ+nB7xJA4AYBHsZQ4X8eTDoOA6VS4QNL8ibsl7uKF024puYpMDyIG1NwFqcXqA2Zz8n4YB+I6EsrLckQvc6gVJLVxmTf8AH8hISaJ+gFZfz7moBzia3cJa9RrLqNh2pbuQVlV5VHJdD5ZHnvn8VmnGR9qzw9BblTClLP+2sMbSj3Gq/ACKbDy/KJOJJKqTtv5ru10reJRyhx/h6mRlSE9igoVKySohb6z39RKttLBSbd0OtI8afEpoCD64SKpNfnayDn0VuRKF/ozkDRFOA5EYpZaLoYtmlX4D9Yy5ml4qxkqc14P5HqD7yWdQkHUdfCxOyuOi+8ryTc5Cp7XvIvWwI7a8ekAApudZSw1RGShlemxRRCUzRomkAZkxePy1o12tvDHwoda8ehnsT39KoiXvLFxvkvPPqoWkRiUSqDpQrXy2B/Mg/UmgH+cJTskRMK+6PDMJB/oWi5ga+kzdoQ=
 matrix:
   include:
-    - python: 2.7
-      env: TOX_ENV=py27-lint
     - python: 3.5
       env: TOX_ENV=py35-lint
-    - python: 2.7
-      env: TOX_ENV=py27-lint-readme
     - python: 3.5
       env: TOX_ENV=py35-pytest
       install:
@@ -23,15 +19,6 @@ matrix:
         # Only run if CODACY_PROJECT_TOKEN is defined.
         # This is not the case for pull requests outside of galaxyproject/ephemeris
         - bash -c 'if [[ -v CODACY_PROJECT_TOKEN ]]  ; then  python-codacy-coverage -r coverage.xml; fi'
-
-    - python: 2.7
-      env: TOX_ENV=py27-pytest
-      services:
-      - docker
-    - python: 2.7
-      env: TOX_ENV=py27
-      services:
-        - docker
     - python: 3.5
       env: TOX_ENV=py35
       services:

--- a/.travis.yml
+++ b/.travis.yml
@@ -5,10 +5,10 @@ env:
     - secure: HwBDtauxcKJQccRk9fYtG90PNdB+KuNcDVY2MK4AVPLHoMCYGABIKJwUj+K9mcqc2wmYhWHfaufLJuMhr3X0FlPknM/aHdh16zUkIckje7WHqvyR2la1AIAMYaMpMikVJiexA6aElOW/aBuVnFolZyz9No+iq3bfF7iVvg2MLWopjMBsWGrHmAIReIVnPXy//Eka73pnwG2WdOjbKnrZfuUQ+nB7xJA4AYBHsZQ4X8eTDoOA6VS4QNL8ibsl7uKF024puYpMDyIG1NwFqcXqA2Zz8n4YB+I6EsrLckQvc6gVJLVxmTf8AH8hISaJ+gFZfz7moBzia3cJa9RrLqNh2pbuQVlV5VHJdD5ZHnvn8VmnGR9qzw9BblTClLP+2sMbSj3Gq/ACKbDy/KJOJJKqTtv5ru10reJRyhx/h6mRlSE9igoVKySohb6z39RKttLBSbd0OtI8afEpoCD64SKpNfnayDn0VuRKF/ozkDRFOA5EYpZaLoYtmlX4D9Yy5ml4qxkqc14P5HqD7yWdQkHUdfCxOyuOi+8ryTc5Cp7XvIvWwI7a8ekAApudZSw1RGShlemxRRCUzRomkAZkxePy1o12tvDHwoda8ehnsT39KoiXvLFxvkvPPqoWkRiUSqDpQrXy2B/Mg/UmgH+cJTskRMK+6PDMJB/oWi5ga+kzdoQ=
 matrix:
   include:
-    - python: 3.5
-      env: TOX_ENV=py35-lint
-    - python: 3.5
-      env: TOX_ENV=py35-pytest
+    - python: 3.6
+      env: TOX_ENV=py36-lint
+    - python: 3.6
+      env: TOX_ENV=py36-pytest
       install:
       - pip install tox
       - pip install codacy-coverage
@@ -19,12 +19,12 @@ matrix:
         # Only run if CODACY_PROJECT_TOKEN is defined.
         # This is not the case for pull requests outside of galaxyproject/ephemeris
         - bash -c 'if [[ -v CODACY_PROJECT_TOKEN ]]  ; then  python-codacy-coverage -r coverage.xml; fi'
-    - python: 3.5
-      env: TOX_ENV=py35
+    - python: 3.6
+      env: TOX_ENV=py36
       services:
         - docker
     - stage: deploy
-      python: '3.5'
+      python: '3.6'
       if: tag IS present
       install:
         - python -m pip install twine

--- a/Makefile
+++ b/Makefile
@@ -111,6 +111,7 @@ open-project:
 
 dist: clean
 	$(IN_VENV) python setup.py sdist bdist_egg bdist_wheel
+	$(IN_VENV) twine check dist/*
 	ls -l dist
 
 release-test-artifacts: dist

--- a/README.rst
+++ b/README.rst
@@ -14,7 +14,7 @@
 .. image:: https://api.codacy.com/project/badge/Grade/e12102174b4e452c871cd2bafedaec60
    :target: https://www.codacy.com/app/galaxyproject/ephemeris?utm_source=github.com&amp;utm_medium=referral&amp;utm_content=galaxyproject/ephemeris&amp;utm_campaign=Badge_Grade
 
-Ephemeris is a small Python library and set of scripts for managing the
+Ephemeris is a small Python 3 library and set of scripts for managing the
 bootstrapping of Galaxy_ plugins - tools, index data, and workflows.
 
 * Free software: Academic Free License version 3.0

--- a/dev-requirements.txt
+++ b/dev-requirements.txt
@@ -11,8 +11,6 @@ sphinx-argparse
 sphinx
 CommonMark
 
-# Used to check readme.
-readme
 # Used for code checking.
 pyflakes
 flake8

--- a/requirements.txt
+++ b/requirements.txt
@@ -4,4 +4,3 @@ bioblend>=0.10.0
 Jinja2
 galaxy-tool-util>=20.9.1
 galaxy-util>=20.9.0
-futures ; python_version < '3'

--- a/requirements.txt
+++ b/requirements.txt
@@ -2,6 +2,6 @@ six>=1.9.0
 PyYAML
 bioblend>=0.10.0
 Jinja2
-galaxy-tool-util>=20.5.0.dev1
-galaxy-util>=20.1.0.dev0  # temporarily needed because this is a pre-release and https://github.com/pypa/pip/issues/988
+galaxy-tool-util>=20.9.1
+galaxy-util>=20.9.0
 futures ; python_version < '3'

--- a/setup.py
+++ b/setup.py
@@ -87,8 +87,10 @@ setup(
         'Topic :: Software Development :: Code Generators',
         'Topic :: Software Development :: Testing',
         'Natural Language :: English',
-        "Programming Language :: Python :: 2",
-        'Programming Language :: Python :: 2.7',
+        "Programming Language :: Python :: 3",
+        'Programming Language :: Python :: 3.6',
+        'Programming Language :: Python :: 3.7',
+        'Programming Language :: Python :: 3.8',
     ],
     test_suite=TEST_DIR,
     tests_require=test_requirements

--- a/src/ephemeris/shed_tools.py
+++ b/src/ephemeris/shed_tools.py
@@ -46,6 +46,7 @@ import yaml
 from bioblend.galaxy.client import ConnectionError
 from bioblend.galaxy.toolshed import ToolShedClient
 from galaxy.tool_util.verify.interactor import (
+    DictClientTestConfig,
     GalaxyInteractorApi,
     verify_tool,
 )
@@ -231,6 +232,7 @@ class InstallRepositoryManager(object):
                    test_user="ephemeris@galaxyproject.org",
                    parallel_tests=1,
                    test_all_versions=False,
+                   client_test_config_path=None,
                    ):
         """Run tool tests for all tools in each repository in supplied tool list or ``self.installed_repositories()``.
         """
@@ -252,6 +254,13 @@ class InstallRepositoryManager(object):
 
         all_test_results = []
         galaxy_interactor = self._get_interactor(test_user, test_user_api_key)
+        if client_test_config_path is not None:
+            with open(client_test_config_path, "r") as f:
+                client_test_config_dict = yaml.full_load(f)
+            client_test_config = DictClientTestConfig(client_test_config_dict.get("tools"))
+        else:
+            client_test_config = None
+
         test_history = galaxy_interactor.new_history()
 
         with ThreadPoolExecutor(max_workers=parallel_tests) as executor:
@@ -265,6 +274,7 @@ class InstallRepositoryManager(object):
                                     tool_test_results=all_test_results,
                                     tests_passed=tests_passed,
                                     test_exceptions=test_exceptions,
+                                    client_test_config=client_test_config,
                                     )
             finally:
                 # Always write report, even if test was cancelled.
@@ -325,17 +335,26 @@ class InstallRepositoryManager(object):
                    test_exceptions,
                    log,
                    test_history=None,
+                   client_test_config=None,
                    ):
         if test_history is None:
             test_history = galaxy_interactor.new_history()
         tool_id = tool["id"]
         tool_version = tool["version"]
+        # If given a tool_id with a version suffix, strip it off so we can treat tool_version
+        # correctly at least in client_test_config.
+        if tool_version and tool_id.endswith("/" + tool_version):
+            tool_id = tool_id[:-len("/" + tool_version)]
+
+        label_base = tool_id
+        if tool_version:
+            label_base += "/" + str(tool_version)
         try:
             tool_test_dicts = galaxy_interactor.get_tool_tests(tool_id, tool_version=tool_version)
         except Exception as e:
             if log:
-                log.warning("Fetching test definition for tool '%s' failed", tool_id, exc_info=True)
-            test_exceptions.append((tool_id, e))
+                log.warning("Fetching test definition for tool '%s' failed", label_base, exc_info=True)
+            test_exceptions.append((label_base, e))
             Results = namedtuple("Results", ["tool_test_results", "tests_passed", "test_exceptions"])
             return Results(tool_test_results=tool_test_results,
                            tests_passed=tests_passed,
@@ -343,7 +362,7 @@ class InstallRepositoryManager(object):
         test_indices = list(range(len(tool_test_dicts)))
 
         for test_index in test_indices:
-            test_id = tool_id + "-" + str(test_index)
+            test_id = label_base + "-" + str(test_index)
 
             def run_test(index, test_id):
 
@@ -360,6 +379,7 @@ class InstallRepositoryManager(object):
                     verify_tool(
                         tool_id, galaxy_interactor, test_index=index, tool_version=tool_version,
                         register_job_data=register, quiet=True, test_history=test_history,
+                        client_test_config=client_test_config,
                     )
                     tests_passed.append(test_id)
                     if log:
@@ -606,6 +626,7 @@ def main():
             test_user=args.test_user,
             parallel_tests=args.parallel_tests,
             test_all_versions=args.test_all_versions,
+            client_test_config_path=args.client_test_config,
         )
     else:
         raise NotImplementedError("This point in the code should not be reached. Please contact the developers.")
@@ -623,6 +644,7 @@ def main():
                 test_user_api_key=args.test_user_api_key,
                 test_user=args.test_user,
                 parallel_tests=args.parallel_tests,
+                client_test_config_path=args.client_test_config
             )
 
 

--- a/src/ephemeris/shed_tools_args.py
+++ b/src/ephemeris/shed_tools_args.py
@@ -33,6 +33,7 @@ def parser():
         test_json="tool_test_output.json",
         test_existing=False,
         parallel_tests=1,
+        client_test_config=None,
     )
 
     # SUBPARSERS
@@ -239,6 +240,12 @@ def parser():
         help="Run tests on all installed versions of tools.  This will only "
              "apply for tools where revisions have not been provided through "
              "the --revisions arg, --tool_file or --tool_yaml."
+    )
+    test_command_parser.add_argument(
+        "--client_test_config",
+        dest="client_test_config",
+        help="Annotate expectations about tools in client testing YAML "
+             "configuration file."
     )
 
     return shed_parser

--- a/src/ephemeris/sleep.py
+++ b/src/ephemeris/sleep.py
@@ -17,6 +17,12 @@ from galaxy.util import unicodify
 from .common_parser import get_common_args
 
 DEFAULT_SLEEP_WAIT = 1
+MESSAGE_KEY_NOT_YET_VALID = "[%02d] Provided key not (yet) valid... %s\n"
+MESSAGE_INVALID_JSON = "[%02d] No valid json returned... %s\n"
+MESSAGE_FETCHING_USER = "[%02d] Connection error fetching user details, exiting with error code. %s\n"
+MESSAGE_KEY_NOT_YET_ADMIN = "[%02d] Provided key not (yet) admin... %s\n"
+MESSAGE_GALAXY_NOT_YET_UP = "[%02d] Galaxy not up yet... %s\n"
+MESSAGE_TIMEOUT = "Failed to contact Galaxy within timeout (%s), exiting with error code.\n"
 
 
 def _parser():
@@ -27,6 +33,12 @@ def _parser():
     parser.add_argument("--timeout",
                         default=0, type=int,
                         help="Galaxy startup timeout in seconds. The default value of 0 waits forever")
+    parser.add_argument("-a", "--api_key",
+                        dest="api_key",
+                        help="Sleep until key becomes available.")
+    parser.add_argument("--ensure_admin",
+                        default=False,
+                        action="store_true")
     return parser
 
 
@@ -47,37 +59,87 @@ class SleepCondition(object):
         self.sleep = False
 
 
-def sleep(galaxy_url, verbose=False, timeout=0, sleep_condition=None):
+def galaxy_wait(galaxy_url, verbose=False, timeout=0, sleep_condition=None, api_key=None, ensure_admin=False):
+    """Pass user_key to ensure it works before returning."""
+    if verbose:
+        sys.stdout.write("calling galaxy_wait with timeout=%s ensure_admin=%s\n\n\n" % (timeout, ensure_admin))
+        sys.stdout.flush()
+
+    version_url = galaxy_url + "/api/version"
+    if api_key:
+        # adding the key to the URL will ensure Galaxy returns invalid responses until
+        # the key is available.
+        version_url = "%s?key=%s" % (version_url, api_key)
+        current_user_url = "%s/api/users/current?key=%s" % (galaxy_url, api_key)
+    else:
+        assert not ensure_admin
+
     if sleep_condition is None:
         sleep_condition = SleepCondition()
 
     count = 0
+    version_obtained = False
+
     while sleep_condition.sleep:
         try:
-            result = requests.get(galaxy_url + '/api/version')
-            try:
-                result = result.json()
-                if verbose:
-                    sys.stdout.write("Galaxy Version: %s\n" % result['version_major'])
-                    sys.stdout.flush()
-                break
-            except ValueError:
-                if verbose:
-                    sys.stdout.write("[%02d] No valid json returned... %s\n" % (count, result.__str__()))
-                    sys.stdout.flush()
+            if not version_obtained:
+                result = requests.get(version_url)
+                if result.status_code == 403:
+                    if verbose:
+                        sys.stdout.write(MESSAGE_KEY_NOT_YET_VALID % (count, result.__str__()))
+                        sys.stdout.flush()
+                else:
+                    try:
+                        result = result.json()
+                        if verbose:
+                            sys.stdout.write("Galaxy Version: %s\n" % result['version_major'])
+                            sys.stdout.flush()
+                        version_obtained = True
+                    except ValueError:
+                        if verbose:
+                            sys.stdout.write(MESSAGE_INVALID_JSON % (count, result.__str__()))
+                            sys.stdout.flush()
+
+            if version_obtained:
+                if ensure_admin:
+                    result = requests.get(current_user_url)
+                    if result.status_code != 200:
+                        if verbose:
+                            sys.stdout.write(MESSAGE_FETCHING_USER % (count, result.__str__()))
+                            sys.stdout.flush()
+                            return False
+
+                    result = result.json()
+                    is_admin = result['is_admin']
+                    if is_admin:
+                        if verbose:
+                            sys.stdout.write("Verified supplied key an admin key.\n")
+                            sys.stdout.flush()
+                        break
+                    else:
+                        if verbose:
+                            sys.stdout.write(MESSAGE_KEY_NOT_YET_ADMIN % (count, result.__str__()))
+                            sys.stdout.flush()
+                else:
+                    break
         except requests.exceptions.ConnectionError as e:
             if verbose:
-                sys.stdout.write("[%02d] Galaxy not up yet... %s\n" % (count, unicodify(e)[:100]))
+                sys.stdout.write(MESSAGE_GALAXY_NOT_YET_UP % (count, unicodify(e)[:100]))
                 sys.stdout.flush()
         count += 1
 
         # If we cannot talk to galaxy and are over the timeout
         if timeout != 0 and count > timeout:
-            sys.stderr.write("Failed to contact Galaxy\n")
+            sys.stderr.write(MESSAGE_TIMEOUT % timeout)
             return False
 
         time.sleep(DEFAULT_SLEEP_WAIT)
 
+    sys.stdout.write("about to do extra random sleep\n\n\n\n\n")
+    sys.stdout.flush()
+    time.sleep(30)
+    sys.stdout.write("Returning from wait!!!!!!!!\n\n\n\n\n")
+    sys.stdout.flush()
     return True
 
 
@@ -87,7 +149,13 @@ def main():
     """
     options = _parse_cli_options()
 
-    galaxy_alive = sleep(galaxy_url=options.galaxy, verbose=options.verbose, timeout=options.timeout)
+    galaxy_alive = galaxy_wait(
+        galaxy_url=options.galaxy,
+        verbose=options.verbose,
+        timeout=options.timeout,
+        api_key=options.api_key,
+        ensure_admin=options.ensure_admin,
+    )
     exit_code = 0 if galaxy_alive else 1
     sys.exit(exit_code)
 

--- a/tests/docker_for_galaxy.py
+++ b/tests/docker_for_galaxy.py
@@ -1,4 +1,5 @@
 from collections import namedtuple
+from time import sleep
 
 import docker
 import pytest
@@ -9,7 +10,10 @@ from ephemeris.sleep import galaxy_wait
 
 # It needs to work well with dev. Alternatively we can pin this to 'master' or another stable branch.
 # Preferably a branch that updates with each stable release
-GALAXY_IMAGE = "bgruening/galaxy-stable:latest"
+GALAXY_IMAGE = "bgruening/galaxy-stable:20.05"
+GALAXY_ADMIN_KEY = "fakekey"
+GALAXY_ADMIN_PASSWORD = "password"
+GALAXY_ADMIN_USER = "admin@galaxy.org"
 
 client = docker.from_env()
 
@@ -41,8 +45,11 @@ def start_container(**kwargs):
     container_url = "http://localhost:{0}".format(exposed_port)
     galaxy_wait(container_url,
                 timeout=60)  # We are only going to wait 60 seconds. These are tests, and we are impatient!
+    print("FOO!!!!!!!!!!\n\n\n\n\n\n\n\n\n\n")
+    print(container.logs())
+    sleep(300)
     yield GalaxyContainer(url=container_url,
                           container=container,
                           attributes=container_attributes,
-                          gi=GalaxyInstance(container_url, key="admin"))
+                          gi=GalaxyInstance(container_url, key=GALAXY_ADMIN_KEY))
     container.remove(force=True)

--- a/tests/docker_for_galaxy.py
+++ b/tests/docker_for_galaxy.py
@@ -48,7 +48,7 @@ def start_container(**kwargs):
     ready = galaxy_wait(container_url,
                         timeout=180,
                         api_key=key,
-                        ensure_admin=ensure_admin)  # We are only going to wait 60 seconds. These are tests, and we are impatient!
+                        ensure_admin=ensure_admin)
     if not ready:
         raise Exception("Failed to wait on Galaxy to start.")
     gi = GalaxyInstance(container_url, key=key)

--- a/tests/test.sh
+++ b/tests/test.sh
@@ -16,4 +16,3 @@ get-tool-list --help
 
 source $TEST_DATA/test_shed_tools.sh
 source $TEST_DATA/test_workflow_and_data.sh
-

--- a/tests/test_library.sh
+++ b/tests/test_library.sh
@@ -13,11 +13,15 @@ function start_container {
     # We start the image with the -P flag that published all exposed container ports
     # to random free ports on the host, since on OS X the container can't be reached
     # through the internal network (https://docs.docker.com/docker-for-mac/networking/#i-cannot-ping-my-containers)
-    CID=$(docker run -d -e GALAXY_CONFIG_WATCH_TOOL_DATA_DIR=True -P bgruening/galaxy-stable)
+    CID=$(docker run -d -e GALAXY_CONFIG_WATCH_TOOL_DATA_DIR=True -P bgruening/galaxy-stable:20.05)
     # We get the webport (https://docs.docker.com/engine/reference/commandline/inspect/#list-all-port-bindings)
     WEB_PORT=$(docker inspect --format="{{(index (index .NetworkSettings.Ports \"$INTERNAL_EXPOSED_WEB_PORT/tcp\") 0).HostPort}}" $CID)
+    GALAXY_ADMIN_KEY="fakekey"
+    GALAXY_ADMIN_PASSWORD="password"
+    GALAXY_ADMIN_USER="admin@galaxy.org"
     echo "Wait for galaxy to start"
     galaxy-wait -g http://localhost:$WEB_PORT -v --timeout 120
+    sleep 120
 }
 
 function start_new_container {

--- a/tests/test_library.sh
+++ b/tests/test_library.sh
@@ -19,9 +19,10 @@ function start_container {
     GALAXY_ADMIN_KEY="fakekey"
     GALAXY_ADMIN_PASSWORD="password"
     GALAXY_ADMIN_USER="admin@galaxy.org"
+    GALAXY_URL="http://localhost:$WEB_PORT"
     echo "Wait for galaxy to start"
-    galaxy-wait -g http://localhost:$WEB_PORT -v --timeout 120
-    sleep 120
+    galaxy-wait -g "${GALAXY_URL}" -a "${GALAXY_ADMIN_KEY}" --ensure_admin -v --timeout 180
+    echo "Return from galaxy-wait $?"
 }
 
 function start_new_container {

--- a/tests/test_run_data_managers.py
+++ b/tests/test_run_data_managers.py
@@ -7,12 +7,14 @@ import time
 
 import pytest
 import yaml
-from docker_for_galaxy import start_container  # noqa: F401 prevent unused error
+from docker_for_galaxy import GALAXY_ADMIN_KEY, GALAXY_ADMIN_PASSWORD, GALAXY_ADMIN_USER, start_container  # noqa: F401 prevent unused error
 
 from ephemeris import run_data_managers
 from ephemeris.run_data_managers import DataManagers
 from ephemeris.shed_tools import InstallRepositoryManager
 from ephemeris.sleep import galaxy_wait
+
+AUTH_BY = "key"
 
 
 class TestRunDataManagers(object):
@@ -39,11 +41,19 @@ class TestRunDataManagers(object):
     def test_run_data_managers(self, start_container):  # noqa: F811 Prevent start_container unused warning.
         """Tests an installation using the command line"""
         container = start_container
-        sys.argv = ["run-data-managers",
-                    "--user", "admin@galaxy.org",
-                    "-p", "admin",
-                    "-g", container.url,
-                    "--config", "tests/run_data_managers.yaml.test"]
+        argv = ["run-data-managers"]
+        if AUTH_BY == "user":
+            argv.extend([
+                "--user", GALAXY_ADMIN_USER,
+                "-p", GALAXY_ADMIN_PASSWORD,
+            ])
+        else:
+            argv.extend(["-a", GALAXY_ADMIN_KEY])
+        argv.extend([
+            "-g", container.url,
+            "--config", "tests/run_data_managers.yaml.test"
+        ])
+        sys.argv = argv
         run_data_managers.main()
 
     def test_run_data_managers_installation_skipped(self, start_container):  # noqa: F811 Prevent start_container unused warning.

--- a/tests/test_shed_tools.sh
+++ b/tests/test_shed_tools.sh
@@ -2,6 +2,7 @@
 
 set -eu
 set -o pipefail
+set -o xtrace
 
 SCRIPT_DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"
 
@@ -14,27 +15,29 @@ echo "Check tool installation with yaml on the commandline"
 # CD Hit was chosen since it is old and seems to be unmaintained. Last update was 2015.
 # Anyone know a smaller tool that could fit its place?
 OLD_TOOL="{'owner':'jjohnson','name':'cdhit','revisions':['34a799d173f7'],'tool_panel_section_label':'CD_HIT'}"
-shed-tools install -y  ${OLD_TOOL} --user admin@galaxy.org -p admin -g http://localhost:$WEB_PORT
+echo "$GALAXY_ADMIN_USER"
+echo "$GALAXY_ADMIN_PASSWORD"
+shed-tools install -y  ${OLD_TOOL} --user "$GALAXY_ADMIN_USER" -p "$GALAXY_ADMIN_PASSWORD" -g http://localhost:$WEB_PORT
 get-tool-list -g http://localhost:$WEB_PORT -o result_tool_list.yaml
 grep "cdhit" result_tool_list.yaml
 grep "34a799d173f7" result_tool_list.yaml #installed revision
 
 echo "Check update function"
-shed-tools update -a admin -g http://localhost:$WEB_PORT
+shed-tools update -a "$GALAXY_ADMIN_KEY" -g http://localhost:$WEB_PORT
 get-tool-list -g http://localhost:$WEB_PORT -o result_tool_list.yaml
 grep "cdhit" result_tool_list.yaml
 grep "28b7a43907f0" result_tool_list.yaml #latest revision
 
 start_new_container
 echo "Check tool installation with command line flags"
-shed-tools install --name cdhit --owner jjohnson --section_label "CD_HIT" --revisions 34a799d173f7 -a admin -g http://localhost:$WEB_PORT
+shed-tools install --name cdhit --owner jjohnson --section_label "CD_HIT" --revisions 34a799d173f7 -a "$GALAXY_ADMIN_KEY" -g http://localhost:$WEB_PORT
 get-tool-list -g http://localhost:$WEB_PORT -o result_tool_list.yaml
 grep "cdhit" result_tool_list.yaml
 grep "34a799d173f7" result_tool_list.yaml #installed revision
 
 start_new_container
 echo "Check tool installation with --latest"
-shed-tools install -y  $OLD_TOOL --user admin@galaxy.org -p admin -g http://localhost:$WEB_PORT --latest
+shed-tools install -y  $OLD_TOOL --user "$GALAXY_ADMIN_USER" -p "$GALAXY_ADMIN_KEY" -g http://localhost:$WEB_PORT --latest
 get-tool-list -g http://localhost:$WEB_PORT -o result_tool_list.yaml
 grep "cdhit" result_tool_list.yaml
 grep "28b7a43907f0" result_tool_list.yaml #latest revision
@@ -43,8 +46,8 @@ start_new_container
 echo "Check tool installation from tool list"
 # Establish the current tool list
 get-tool-list -g http://localhost:$WEB_PORT -o result_tool_list_pre.yaml
-shed-tools install -t "$TEST_DATA"/tool_list.yaml.sample -a admin -g http://localhost:$WEB_PORT
-get-tool-list -g http://localhost:$WEB_PORT -a admin --get_all_tools -o result_tool_list_post.yaml
+shed-tools install -t "$TEST_DATA"/tool_list.yaml.sample -a "$GALAXY_ADMIN_KEY" -g http://localhost:$WEB_PORT
+get-tool-list -g http://localhost:$WEB_PORT -a "$GALAXY_ADMIN_KEY" --get_all_tools -o result_tool_list_post.yaml
 grep 4d82cf59895e result_tool_list_post.yaml && \
 grep 0b4e36026794 result_tool_list_post.yaml && \
 grep 051eba708f43 result_tool_list_post.yaml   # this means all revisions have been successfully installed.

--- a/tests/test_shed_tools.sh
+++ b/tests/test_shed_tools.sh
@@ -17,37 +17,38 @@ echo "Check tool installation with yaml on the commandline"
 OLD_TOOL="{'owner':'jjohnson','name':'cdhit','revisions':['34a799d173f7'],'tool_panel_section_label':'CD_HIT'}"
 echo "$GALAXY_ADMIN_USER"
 echo "$GALAXY_ADMIN_PASSWORD"
-shed-tools install -y  ${OLD_TOOL} --user "$GALAXY_ADMIN_USER" -p "$GALAXY_ADMIN_PASSWORD" -g http://localhost:$WEB_PORT
-get-tool-list -g http://localhost:$WEB_PORT -o result_tool_list.yaml
+shed-tools install -y  ${OLD_TOOL} --user "$GALAXY_ADMIN_USER" -p "$GALAXY_ADMIN_PASSWORD" -g "${GALAXY_URL}"
+get-tool-list -g "${GALAXY_URL}" -o result_tool_list.yaml
 grep "cdhit" result_tool_list.yaml
 grep "34a799d173f7" result_tool_list.yaml #installed revision
 
 echo "Check update function"
-shed-tools update -a "$GALAXY_ADMIN_KEY" -g http://localhost:$WEB_PORT
-get-tool-list -g http://localhost:$WEB_PORT -o result_tool_list.yaml
+shed-tools update -a "$GALAXY_ADMIN_KEY" -g "${GALAXY_URL}"
+get-tool-list -g "${GALAXY_URL}" -o result_tool_list.yaml
 grep "cdhit" result_tool_list.yaml
 grep "28b7a43907f0" result_tool_list.yaml #latest revision
 
 start_new_container
 echo "Check tool installation with command line flags"
-shed-tools install --name cdhit --owner jjohnson --section_label "CD_HIT" --revisions 34a799d173f7 -a "$GALAXY_ADMIN_KEY" -g http://localhost:$WEB_PORT
-get-tool-list -g http://localhost:$WEB_PORT -o result_tool_list.yaml
+shed-tools install --name cdhit --owner jjohnson --section_label "CD_HIT" --revisions 34a799d173f7 -a "$GALAXY_ADMIN_KEY" -g "${GALAXY_URL}"
+get-tool-list -g "${GALAXY_URL}" -o result_tool_list.yaml
 grep "cdhit" result_tool_list.yaml
 grep "34a799d173f7" result_tool_list.yaml #installed revision
 
 start_new_container
 echo "Check tool installation with --latest"
-shed-tools install -y  $OLD_TOOL --user "$GALAXY_ADMIN_USER" -p "$GALAXY_ADMIN_KEY" -g http://localhost:$WEB_PORT --latest
-get-tool-list -g http://localhost:$WEB_PORT -o result_tool_list.yaml
+shed-tools install -y  $OLD_TOOL --user "$GALAXY_ADMIN_USER" -p "$GALAXY_ADMIN_PASSWORD" -g "${GALAXY_URL}" --latest
+get-tool-list -g "${GALAXY_URL}" -o result_tool_list.yaml
+cat result_tool_list.yaml
 grep "cdhit" result_tool_list.yaml
 grep "28b7a43907f0" result_tool_list.yaml #latest revision
 
 start_new_container
 echo "Check tool installation from tool list"
 # Establish the current tool list
-get-tool-list -g http://localhost:$WEB_PORT -o result_tool_list_pre.yaml
-shed-tools install -t "$TEST_DATA"/tool_list.yaml.sample -a "$GALAXY_ADMIN_KEY" -g http://localhost:$WEB_PORT
-get-tool-list -g http://localhost:$WEB_PORT -a "$GALAXY_ADMIN_KEY" --get_all_tools -o result_tool_list_post.yaml
+get-tool-list -g "${GALAXY_URL}" -o result_tool_list_pre.yaml
+shed-tools install -t "$TEST_DATA"/tool_list.yaml.sample -a "$GALAXY_ADMIN_KEY" -g "${GALAXY_URL}"
+get-tool-list -g "${GALAXY_URL}" -a "$GALAXY_ADMIN_KEY" --get_all_tools -o result_tool_list_post.yaml
 grep 4d82cf59895e result_tool_list_post.yaml && \
 grep 0b4e36026794 result_tool_list_post.yaml && \
 grep 051eba708f43 result_tool_list_post.yaml   # this means all revisions have been successfully installed.

--- a/tests/test_workflow_and_data.sh
+++ b/tests/test_workflow_and_data.sh
@@ -12,20 +12,20 @@ start_container
 docker ps
 
 echo "Check workflow installation"
-workflow-install --user admin@galaxy.org -p admin -g http://localhost:$WEB_PORT -w "$TEST_DATA"/test_workflow.ga
-workflow-install -a admin -g http://localhost:$WEB_PORT -w "$TEST_DATA"/test_workflow.ga
+workflow-install --user admin@galaxy.org -p password -g http://localhost:$WEB_PORT -w "$TEST_DATA"/test_workflow.ga
+workflow-install -a "$GALAXY_ADMIN_KEY" -g http://localhost:$WEB_PORT -w "$TEST_DATA"/test_workflow.ga
 
 echo "Populate data libraries"
-setup-data-libraries --user admin@galaxy.org -p admin -g http://localhost:$WEB_PORT -i "$TEST_DATA"/library_data_example.yaml
-setup-data-libraries -a admin -g http://localhost:$WEB_PORT -i "$TEST_DATA"/library_data_example.yaml
-setup-data-libraries -a admin -g http://localhost:$WEB_PORT -i "$TEST_DATA"/library_data_example_legacy.yaml
+setup-data-libraries --user admin@galaxy.org -p password -g http://localhost:$WEB_PORT -i "$TEST_DATA"/library_data_example.yaml
+setup-data-libraries -a "$GALAXY_ADMIN_KEY" -g http://localhost:$WEB_PORT -i "$TEST_DATA"/library_data_example.yaml
+setup-data-libraries -a "$GALAXY_ADMIN_KEY" -g http://localhost:$WEB_PORT -i "$TEST_DATA"/library_data_example_legacy.yaml
 
 echo "Get tool list from Galaxy"
 get-tool-list -g http://localhost:$WEB_PORT -o result_tool_list.yaml
 workflow-to-tools -w "$TEST_DATA"/test_workflow_2.ga -o result_workflow_to_tools.yaml
 
 echo "Check tool installation from workflow"
-shed-tools install -t result_workflow_to_tools.yaml -a admin -g http://localhost:$WEB_PORT
-shed-tools install -t result_workflow_to_tools.yaml --user admin@galaxy.org -p admin -g http://localhost:$WEB_PORT
+shed-tools install -t result_workflow_to_tools.yaml -a "$GALAXY_ADMIN_KEY" -g http://localhost:$WEB_PORT
+shed-tools install -t result_workflow_to_tools.yaml --user admin@galaxy.org -p password -g http://localhost:$WEB_PORT
 
 docker rm -f $CID

--- a/tests/test_workflow_and_data.sh
+++ b/tests/test_workflow_and_data.sh
@@ -12,20 +12,20 @@ start_container
 docker ps
 
 echo "Check workflow installation"
-workflow-install --user admin@galaxy.org -p password -g http://localhost:$WEB_PORT -w "$TEST_DATA"/test_workflow.ga
-workflow-install -a "$GALAXY_ADMIN_KEY" -g http://localhost:$WEB_PORT -w "$TEST_DATA"/test_workflow.ga
+workflow-install --user admin@galaxy.org -p password -g "${GALAXY_URL}" -w "$TEST_DATA"/test_workflow.ga
+workflow-install -a "$GALAXY_ADMIN_KEY" -g "${GALAXY_URL}" -w "$TEST_DATA"/test_workflow.ga
 
 echo "Populate data libraries"
-setup-data-libraries --user admin@galaxy.org -p password -g http://localhost:$WEB_PORT -i "$TEST_DATA"/library_data_example.yaml
-setup-data-libraries -a "$GALAXY_ADMIN_KEY" -g http://localhost:$WEB_PORT -i "$TEST_DATA"/library_data_example.yaml
-setup-data-libraries -a "$GALAXY_ADMIN_KEY" -g http://localhost:$WEB_PORT -i "$TEST_DATA"/library_data_example_legacy.yaml
+setup-data-libraries --user admin@galaxy.org -p password -g "${GALAXY_URL}" -i "$TEST_DATA"/library_data_example.yaml
+setup-data-libraries -a "$GALAXY_ADMIN_KEY" -g "${GALAXY_URL}" -i "$TEST_DATA"/library_data_example.yaml
+setup-data-libraries -a "$GALAXY_ADMIN_KEY" -g "${GALAXY_URL}" -i "$TEST_DATA"/library_data_example_legacy.yaml
 
 echo "Get tool list from Galaxy"
-get-tool-list -g http://localhost:$WEB_PORT -o result_tool_list.yaml
+get-tool-list -g "${GALAXY_URL}" -o result_tool_list.yaml
 workflow-to-tools -w "$TEST_DATA"/test_workflow_2.ga -o result_workflow_to_tools.yaml
 
 echo "Check tool installation from workflow"
-shed-tools install -t result_workflow_to_tools.yaml -a "$GALAXY_ADMIN_KEY" -g http://localhost:$WEB_PORT
-shed-tools install -t result_workflow_to_tools.yaml --user admin@galaxy.org -p password -g http://localhost:$WEB_PORT
+shed-tools install -t result_workflow_to_tools.yaml -a "$GALAXY_ADMIN_KEY" -g "${GALAXY_URL}"
+shed-tools install -t result_workflow_to_tools.yaml --user admin@galaxy.org -p password -g "${GALAXY_URL}"
 
 docker rm -f $CID

--- a/tox.ini
+++ b/tox.ini
@@ -1,6 +1,6 @@
 # TODO: implement doc linting
 [tox]
-envlist = py{27,35}-lint, py27-lint-readme,py{27,35}-pytest, py{27,35}
+envlist = py{36}-lint, py{36}-pytest, py{36}, py{36}-integration
 source_dir = src/ephemeris
 test_dir = tests
 
@@ -8,35 +8,14 @@ test_dir = tests
 commands = {envpython} setup.py nosetests []
 whitelist_externals = bash
 
-[testenv:py27-lint]
+[testenv:py36-lint]
 commands = flake8 {[tox]source_dir} {[tox]test_dir}
 skip_install = True
 deps =
     flake8
     flake8-import-order
 
-[testenv:py35-lint]
-commands = flake8 {[tox]source_dir} {[tox]test_dir}
-skip_install = True
-deps =
-    flake8
-    flake8-import-order
-
-[testenv:py27-lint-readme]
-commands = make lint-readme
-skip_install = True
-whitelist_externals = make
-deps =
-    readme
-
-[testenv:py27-pytest]
-deps =
-    -r requirements.txt
-    pytest
-    docker
-commands = pytest -v {[tox]test_dir}
-
-[testenv:py35-pytest]
+[testenv:py36-pytest]
 deps =
     -r requirements.txt
     pytest
@@ -53,12 +32,12 @@ commands =
     # Unfortunately this has to run in the tox env to have access to envsitepackagesdir
     sed -i 's#{envsitepackagesdir}#src#' coverage.xml
 
-[testenv:py27]
+[testenv:py36]
 deps =
     -r requirements.txt
 commands = bash {[tox]test_dir}/test.sh
 
-[testenv:py35]
+[testenv:py36-integration]
 deps =
     -r requirements.txt
 commands = bash {[tox]test_dir}/test.sh


### PR DESCRIPTION
- Migrate most testing and linting to Github actions.
- Bring in the latest changes to sleep function from Planemo.
- Update sleep to allow waiting for a key to become an admin key (new Docker container is way different, the web server becomes active before the key works and the key works before it is an admin key). 😅 
- Update tests for changes to docker API key and admin user password.
- Bring in client configuration tests from my last PR.
- Drop Python 2.7 and 3.5 support.