### PR TITLE
Simplify tox.ini, base testing on galaxy-compose

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -24,7 +24,5 @@ jobs:
           python -m pip install --upgrade pip
           pip install tox coveralls
       - name: Test with tox
-        run: |
-          TOXENV=$(echo $TOXENV | sed 's/\.//') tox
         env:
-          TOXENV: py${{ matrix.python-version }}-${{ matrix.tox-action }}
+          TOXENV: ${{ matrix.tox-action }}

--- a/dev-requirements.txt
+++ b/dev-requirements.txt
@@ -4,6 +4,7 @@ coverage
 pytest
 pytest-cov
 docker
+jinja2
 
 #Building Docs
 sphinx_rtd_theme

--- a/tests/docker_for_galaxy.py
+++ b/tests/docker_for_galaxy.py
@@ -126,12 +126,6 @@ class GalaxyService:
     def restart_galaxy(self):
         self.galaxy_container.restart()
 
-    def __del__(self):
-        try:
-            self.remove(force=True)
-        except:
-            pass
-
 
 # Class scope is chosen here so we can group tests on the same galaxy in a class.
 @pytest.fixture(scope="class")

--- a/tests/docker_for_galaxy.py
+++ b/tests/docker_for_galaxy.py
@@ -1,22 +1,87 @@
+import os
+import random
+import tempfile
 from collections import namedtuple
+from pathlib import Path
+from typing import Optional, Any, Union
+
+from bioblend.galaxy import GalaxyInstance
 
 import docker
-import pytest
-from bioblend.galaxy import GalaxyInstance
 
 from ephemeris.sleep import galaxy_wait
 
+import jinja2
+
+import pytest
 
 # It needs to work well with dev. Alternatively we can pin this to 'master' or another stable branch.
 # Preferably a branch that updates with each stable release
-GALAXY_IMAGE = "bgruening/galaxy-stable:20.05"
+GALAXY_IMAGE = "galaxy/galaxy-k8s:21.01"
 GALAXY_ADMIN_KEY = "fakekey"
 GALAXY_ADMIN_PASSWORD = "password"
 GALAXY_ADMIN_USER = "admin@galaxy.org"
 
+POSTGRES_IMAGE = "postgres:13"
+NGINX_IMAGE = "nginx:1.18"
+NGINX_TEMPLATE = Path(__file__).parent / "files" / "galaxy.nginx.j2"
+CREATE_GALAXY_USER_PY = Path(__file__).parent / "files" / "create_galaxy_user.py"
+
 client = docker.from_env()
 
-GalaxyContainer = namedtuple('GalaxyContainer', ['url', 'container', 'attributes', 'gi'])
+GalaxyContainer = namedtuple('GalaxyContainer',
+                             ['url', 'container', 'attributes', 'gi'])
+
+
+def template_to_temp(template: Union[os.PathLike, str], **kwargs):
+    template_string = Path(template).read_text()
+    templated = jinja2.Template(template_string)
+    with tempfile.NamedTemporaryFile('wt', delete=False) as temp_file:
+        temp_file.write(templated.render(**kwargs))
+    return temp_file.name
+
+
+def get_container_url(container, port: str) -> str:
+    container_attributes = client.containers.get(container.id).attrs
+    network_settings = container_attributes.get('NetworkSettings')
+    ports = network_settings.get('Ports')
+    host_port = ports.get(port)[0].get('HostPort')
+    return f"http://localhost:{host_port}"
+
+
+class GalaxyService:
+
+    def __init__(self,
+                 api_key: Optional[str] = None):
+        self.id = hex(random.randint(0, 2**32-1)).lstrip("0x")
+        self.network_name = f"galaxy_{self.id}"
+        self.postgres_name = f"ephemeris_db_{self.id}"
+        self.galaxy_web_name = f"galaxy_web_{self.id}"
+        self.nginx_template = template_to_temp(NGINX_TEMPLATE,
+                                               galaxy_web=self.galaxy_web_name)
+        self.network = client.networks.create(self.network_name)
+        self.postgres_container = client.containers.run(
+            POSTGRES_IMAGE, detach=True, network=self.network_name,
+            name="ephemeris_db",
+            environment=dict(
+                POSTGRES_USER="dbuser",
+                POSTGRES_ROOT_PASSWORD="secret",
+                POSTGRES_PASSWORD="secret",
+                POSTGRES_DB="galaxydb"
+            ))
+        self.galaxy_container = client.containers.run(
+            GALAXY_IMAGE, detach=True, network=self.network_name,
+            name="ephemeris_galaxy",
+            volumes=[f"{str(CREATE_GALAXY_USER_PY)}:/usr/local/bin/create_galaxy_user.py"],
+            environment=dict(
+                GALAXY_CONFIG_DATABASE_CONNECTION="postgresql://ephemeris_db/galaxydb?client_encoding=utf8",
+                PGUSER="dbuser",
+                PGPASSWORD="secret"
+            ))
+        self.nginx_container = client.containers.run(
+            NGINX_IMAGE, detach=True, network=self.network_name,
+            ports={'80/tcp': None})
+        self.url = get_container_url(self.nginx_container, '80/tcp')
 
 
 # Class scope is chosen here so we can group tests on the same galaxy in a class.
@@ -31,7 +96,8 @@ def start_container(**kwargs):
     key = kwargs.get("api_key", GALAXY_ADMIN_KEY)
     ensure_admin = kwargs.get("ensure_admin", True)
 
-    container = client.containers.run(GALAXY_IMAGE, detach=True, ports={'80/tcp': None}, **kwargs)
+    container = client.containers.run(GALAXY_IMAGE, detach=True,
+                                      ports={'80/tcp': None}, **kwargs)
     container_id = container.attrs.get('Id')
     print(container_id)
 
@@ -41,7 +107,9 @@ def start_container(**kwargs):
     container_attributes = client.containers.get(container_id).attrs
 
     # Venturing into deep nested dictionaries.
-    exposed_port = container_attributes.get('NetworkSettings').get('Ports').get('80/tcp')[0].get('HostPort')
+    exposed_port = \
+    container_attributes.get('NetworkSettings').get('Ports').get('80/tcp')[
+        0].get('HostPort')
 
     container_url = "http://localhost:{0}".format(exposed_port)
     assert key

--- a/tests/docker_for_galaxy.py
+++ b/tests/docker_for_galaxy.py
@@ -17,7 +17,7 @@ from ephemeris.sleep import galaxy_wait
 
 # It needs to work well with dev. Alternatively we can pin this to 'master' or another stable branch.
 # Preferably a branch that updates with each stable release
-GALAXY_IMAGE = "galaxy/galaxy-k8s:21.01"
+GALAXY_IMAGE = "lumc/galaxy-compose:21.01"
 GALAXY_ADMIN_KEY = "fakekey"
 GALAXY_ADMIN_PASSWORD = "password"
 GALAXY_ADMIN_USER = "admin@galaxy.org"
@@ -97,13 +97,13 @@ class GalaxyService:
         time.sleep(2)  # We wait for the database to be created
         self.api_key = api_key or GALAXY_ADMIN_KEY
         result = self.galaxy_container.exec_run([
-            "/galaxy/server/.venv/bin/python",
+            "/galaxy/venv/bin/python",
             "/usr/local/bin/create_galaxy_user.py",
             "--user", GALAXY_ADMIN_USER,
             "--username", "admin",
             "--key", self.api_key,
             "--password", GALAXY_ADMIN_PASSWORD,
-            "-c", "/galaxy/server/config/galaxy.yml"
+            "-c", "/galaxy/config/galaxy.yml"
         ], workdir="/galaxy/server")
         if result.exit_code != 0:
             raise RuntimeError(f"Error when creating API Key: {result.output}")

--- a/tests/docker_for_galaxy.py
+++ b/tests/docker_for_galaxy.py
@@ -84,6 +84,7 @@ class GalaxyService:
             environment=dict(
                 GALAXY_CONFIG_DATABASE_CONNECTION=f"postgresql://{self.postgres_name}/galaxydb?client_encoding=utf8",
                 GALAXY_CONFIG_ADMIN_USERS=GALAXY_ADMIN_USER,
+                GALAXY_CONFIG_JOB_CONFIG_FILE="job_conf.xml.sample_basic",  # Use basic job conf xml not kubernetes one.
                 PGUSER="dbuser",
                 PGPASSWORD="secret"
             ))
@@ -128,7 +129,7 @@ class GalaxyService:
     def __del__(self):
         try:
             self.remove(force=True)
-        except docker.errors.NotFound:
+        except:
             pass
 
 

--- a/tests/docker_for_galaxy.py
+++ b/tests/docker_for_galaxy.py
@@ -3,17 +3,16 @@ import random
 import tempfile
 from collections import namedtuple
 from pathlib import Path
-from typing import Optional, Any, Union
-
-from bioblend.galaxy import GalaxyInstance
+from typing import Optional, Union
 
 import docker
+import jinja2
+import pytest
+from bioblend.galaxy import GalaxyInstance
+from docker.models.containers import Container
 
 from ephemeris.sleep import galaxy_wait
 
-import jinja2
-
-import pytest
 
 # It needs to work well with dev. Alternatively we can pin this to 'master' or another stable branch.
 # Preferably a branch that updates with each stable release
@@ -53,35 +52,51 @@ class GalaxyService:
 
     def __init__(self,
                  api_key: Optional[str] = None):
+        self.client = docker.from_env()
         self.id = hex(random.randint(0, 2**32-1)).lstrip("0x")
         self.network_name = f"galaxy_{self.id}"
         self.postgres_name = f"ephemeris_db_{self.id}"
         self.galaxy_web_name = f"galaxy_web_{self.id}"
-        self.nginx_template = template_to_temp(NGINX_TEMPLATE,
-                                               galaxy_web=self.galaxy_web_name)
-        self.network = client.networks.create(self.network_name)
-        self.postgres_container = client.containers.run(
+        self.nginx_config = template_to_temp(NGINX_TEMPLATE,
+                                             galaxy_web=self.galaxy_web_name)
+        self.network = self.client.networks.create(self.network_name)
+        self.postgres_container: Container = self.client.containers.run(
             POSTGRES_IMAGE, detach=True, network=self.network_name,
-            name="ephemeris_db",
+            name=self.postgres_name,
             environment=dict(
                 POSTGRES_USER="dbuser",
                 POSTGRES_ROOT_PASSWORD="secret",
                 POSTGRES_PASSWORD="secret",
                 POSTGRES_DB="galaxydb"
             ))
-        self.galaxy_container = client.containers.run(
+        self.galaxy_container: Container = self.client.containers.run(
             GALAXY_IMAGE, detach=True, network=self.network_name,
-            name="ephemeris_galaxy",
+            name=self.galaxy_web_name,
             volumes=[f"{str(CREATE_GALAXY_USER_PY)}:/usr/local/bin/create_galaxy_user.py"],
             environment=dict(
-                GALAXY_CONFIG_DATABASE_CONNECTION="postgresql://ephemeris_db/galaxydb?client_encoding=utf8",
+                GALAXY_CONFIG_DATABASE_CONNECTION=f"postgresql://{self.postgres_name}/galaxydb?client_encoding=utf8",
                 PGUSER="dbuser",
                 PGPASSWORD="secret"
             ))
-        self.nginx_container = client.containers.run(
+        self.nginx_container: Container = self.client.containers.run(
             NGINX_IMAGE, detach=True, network=self.network_name,
-            ports={'80/tcp': None})
+            ports={'80/tcp': None},
+            volumes=[f"{str(self.nginx_config)}:/etc/nginx/conf.d/default.conf"])
         self.url = get_container_url(self.nginx_container, '80/tcp')
+
+    def stop(self, **kwargs):
+        self.galaxy_container.stop(**kwargs)
+        self.nginx_container.stop(**kwargs)
+        self.postgres_container.stop(**kwargs)
+
+    def remove(self, **kwargs):
+        self.galaxy_container.remove(**kwargs)
+        self.nginx_container.remove(**kwargs)
+        self.postgres_container.remove(**kwargs)
+        os.remove(self.nginx_config)
+
+    def restart_galaxy(self):
+        self.galaxy_container.restart()
 
 
 # Class scope is chosen here so we can group tests on the same galaxy in a class.
@@ -107,9 +122,7 @@ def start_container(**kwargs):
     container_attributes = client.containers.get(container_id).attrs
 
     # Venturing into deep nested dictionaries.
-    exposed_port = \
-    container_attributes.get('NetworkSettings').get('Ports').get('80/tcp')[
-        0].get('HostPort')
+    exposed_port = container_attributes.get('NetworkSettings').get('Ports').get('80/tcp')[0].get('HostPort')
 
     container_url = "http://localhost:{0}".format(exposed_port)
     assert key

--- a/tests/docker_for_galaxy.py
+++ b/tests/docker_for_galaxy.py
@@ -15,15 +15,14 @@ from docker.models.containers import Container
 from ephemeris.sleep import galaxy_wait
 
 
-# It needs to work well with dev. Alternatively we can pin this to 'master' or another stable branch.
-# Preferably a branch that updates with each stable release
-GALAXY_IMAGE = "lumc/galaxy-compose:21.01"
+# Latest will be the latest stable version
+GALAXY_IMAGE = "lumc/galaxy-compose:latest"
 GALAXY_ADMIN_KEY = "fakekey"
 GALAXY_ADMIN_PASSWORD = "password"
 GALAXY_ADMIN_USER = "admin@galaxy.org"
 
-POSTGRES_IMAGE = "postgres:13"
-NGINX_IMAGE = "nginx:1.18"
+POSTGRES_IMAGE = "postgres:latest"  # Use the latest stable version
+NGINX_IMAGE = "nginx:stable"  # Use the latest stable version
 NGINX_TEMPLATE = Path(__file__).parent / "files" / "galaxy.nginx.j2"
 CREATE_GALAXY_USER_PY = Path(__file__).parent / "files" / "create_galaxy_user.py"
 

--- a/tests/docker_for_galaxy.py
+++ b/tests/docker_for_galaxy.py
@@ -1,7 +1,6 @@
 import os
 import random
 import tempfile
-import time
 from collections import namedtuple
 from pathlib import Path
 from typing import Optional, Union, Generator
@@ -93,7 +92,7 @@ class GalaxyService:
             volumes=[f"{str(self.nginx_config)}:/etc/nginx/conf.d/default.conf"])
 
         # Create admin api_key user in galaxy.
-        time.sleep(2)  # We wait for the database to be created
+        galaxy_wait(get_container_url(self.nginx_container, "80/tcp"))
         self.api_key = api_key or GALAXY_ADMIN_KEY
         result = self.galaxy_container.exec_run([
             "/galaxy/venv/bin/python",

--- a/tests/files/create_galaxy_user.py
+++ b/tests/files/create_galaxy_user.py
@@ -1,0 +1,60 @@
+#!/usr/bin/env python3
+import sys
+sys.path.insert(1, '/galaxy/server')
+sys.path.insert(1,'/galaxy/server/lib')
+
+from galaxy.model import User, APIKeys
+from galaxy.model.mapping import init
+from galaxy.model.orm.scripts import get_config
+import argparse
+
+def add_user(sa_session, security_agent, email, password, key=None, username="admin"):
+    """
+        Add Galaxy User.
+        From John https://gist.github.com/jmchilton/4475646
+    """
+    query = sa_session.query( User ).filter_by( email=email )
+    if query.count() > 0:
+        return query.first()
+    else:
+        User.use_pbkdf2 = False
+        user = User(email)
+        user.username = username
+        user.set_password_cleartext(password)
+        sa_session.add(user)
+        sa_session.flush()
+
+        security_agent.create_private_user_role( user )
+        if not user.default_permissions:
+            security_agent.user_set_default_permissions( user, history=True, dataset=True )
+
+        if key is not None:
+            api_key = APIKeys()
+            api_key.user_id = user.id
+            api_key.key = key
+            sa_session.add(api_key)
+            sa_session.flush()
+        return user
+
+
+if __name__ == "__main__":
+    db_url = get_config(sys.argv, use_argparse=False)['db_url']
+
+    parser = argparse.ArgumentParser(description='Create Galaxy Admin User.')
+
+    parser.add_argument("--user", required=True,
+                    help="Username, it should be an email address.")
+    parser.add_argument("--password", required=True,
+                    help="Password.")
+    parser.add_argument("--key", help="API-Key.")
+    parser.add_argument("--username", default="admin",
+                    help="The public username. Public names must be at least three characters in length and contain only lower-case letters, numbers, and the '-' character.")
+    parser.add_argument('args', nargs=argparse.REMAINDER)
+
+    options = parser.parse_args()
+
+    mapping = init('/tmp/', db_url)
+    sa_session = mapping.context
+    security_agent = mapping.security_agent
+
+    add_user(sa_session, security_agent, options.user, options.password, key=options.key, username=options.username)

--- a/tests/files/create_galaxy_user.py
+++ b/tests/files/create_galaxy_user.py
@@ -1,19 +1,22 @@
 #!/usr/bin/env python3
+import argparse
 import sys
-sys.path.insert(1, '/galaxy/server')
-sys.path.insert(1,'/galaxy/server/lib')
 
-from galaxy.model import User, APIKeys
+from galaxy.model import APIKeys, User
 from galaxy.model.mapping import init
 from galaxy.model.orm.scripts import get_config
-import argparse
 
-def add_user(sa_session, security_agent, email, password, key=None, username="admin"):
+sys.path.insert(1, '/galaxy/server')
+sys.path.insert(1, '/galaxy/server/lib')
+
+
+def add_user(sa_session, security_agent, email, password, key=None,
+             username="admin"):
     """
         Add Galaxy User.
         From John https://gist.github.com/jmchilton/4475646
     """
-    query = sa_session.query( User ).filter_by( email=email )
+    query = sa_session.query(User).filter_by(email=email)
     if query.count() > 0:
         return query.first()
     else:
@@ -24,9 +27,10 @@ def add_user(sa_session, security_agent, email, password, key=None, username="ad
         sa_session.add(user)
         sa_session.flush()
 
-        security_agent.create_private_user_role( user )
+        security_agent.create_private_user_role(user)
         if not user.default_permissions:
-            security_agent.user_set_default_permissions( user, history=True, dataset=True )
+            security_agent.user_set_default_permissions(user, history=True,
+                                                        dataset=True)
 
         if key is not None:
             api_key = APIKeys()
@@ -43,12 +47,15 @@ if __name__ == "__main__":
     parser = argparse.ArgumentParser(description='Create Galaxy Admin User.')
 
     parser.add_argument("--user", required=True,
-                    help="Username, it should be an email address.")
+                        help="Username, it should be an email address.")
     parser.add_argument("--password", required=True,
-                    help="Password.")
+                        help="Password.")
     parser.add_argument("--key", help="API-Key.")
     parser.add_argument("--username", default="admin",
-                    help="The public username. Public names must be at least three characters in length and contain only lower-case letters, numbers, and the '-' character.")
+                        help="The public username. Public names must be at "
+                             "least three characters in length and contain "
+                             "only lower-case letters, numbers, and the '-' "
+                             "character.")
     parser.add_argument('args', nargs=argparse.REMAINDER)
 
     options = parser.parse_args()
@@ -57,4 +64,5 @@ if __name__ == "__main__":
     sa_session = mapping.context
     security_agent = mapping.security_agent
 
-    add_user(sa_session, security_agent, options.user, options.password, key=options.key, username=options.username)
+    add_user(sa_session, security_agent, options.user, options.password,
+             key=options.key, username=options.username)

--- a/tests/files/create_galaxy_user.py
+++ b/tests/files/create_galaxy_user.py
@@ -2,12 +2,12 @@
 import argparse
 import sys
 
-from galaxy.model import APIKeys, User
-from galaxy.model.mapping import init
-from galaxy.model.orm.scripts import get_config
-
 sys.path.insert(1, '/galaxy/server')
 sys.path.insert(1, '/galaxy/server/lib')
+
+from galaxy.model import APIKeys, User  # noqa: E402, import must be after sys.path.insert
+from galaxy.model.mapping import init  # noqa: E402
+from galaxy.model.orm.scripts import get_config  # noqa: E402
 
 
 def add_user(sa_session, security_agent, email, password, key=None,

--- a/tests/files/galaxy.nginx.j2
+++ b/tests/files/galaxy.nginx.j2
@@ -14,10 +14,8 @@ server {
 
   location / {
     proxy_pass http://{{galaxy_web}}:8080;
-    proxy_set_header X-URL-SCHEME https;
     proxy_set_header X-Forwarded-Port $server_port;
     proxy_set_header X-Forwarded-Host $host;
-    proxy_set_header X-Real-IP $remote_addr;
     proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
     }
 }

--- a/tests/files/galaxy.nginx.j2
+++ b/tests/files/galaxy.nginx.j2
@@ -12,10 +12,15 @@ server {
     gzip_types text/plain text/css application/json application/x-javascript text/xml application/xml application/xml+rss text/javascript;
     gzip_buffers 16 8k;
 
-  location / {
-    proxy_pass http://{{galaxy_web}}:8080;
-    proxy_set_header X-Forwarded-Port $server_port;
-    proxy_set_header X-Forwarded-Host $host;
-    proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+    location / {
+        include uwsgi_params;
+        # allow up to 3 minutes for Galaxy to respond to slow requests before timing out
+        uwsgi_read_timeout 180;
+        # maximum file upload size
+        uwsgi_pass uwsgi://{{galaxy_web}}:3031;
+        uwsgi_param Host $host;
+        uwsgi_param X-Real-IP $remote_addr;
+        uwsgi_param X-Forwarded-For $proxy_add_x_forwarded_for;
+        uwsgi_param X-Forwarded-Proto $http_x_forwarded_proto;
     }
 }

--- a/tests/files/galaxy.nginx.j2
+++ b/tests/files/galaxy.nginx.j2
@@ -1,0 +1,23 @@
+server {
+    listen 80 default_server;
+    listen [::]:80 default_server;
+    server_name _;
+
+    # compress responses whenever possible
+    gzip on;
+    gzip_http_version 1.1;
+    gzip_vary on;
+    gzip_comp_level 6;
+    gzip_proxied any;
+    gzip_types text/plain text/css application/json application/x-javascript text/xml application/xml application/xml+rss text/javascript;
+    gzip_buffers 16 8k;
+
+  location / {
+    proxy_pass http://{{galaxy_web}}:8080;
+    proxy_set_header X-URL-SCHEME https;
+    proxy_set_header X-Forwarded-Port $server_port;
+    proxy_set_header X-Forwarded-Host $host;
+    proxy_set_header X-Real-IP $remote_addr;
+    proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+    }
+}

--- a/tests/test_shed_tools.py
+++ b/tests/test_shed_tools.py
@@ -9,7 +9,7 @@ import os
 import tempfile
 
 import pytest
-from docker_for_galaxy import start_container  # noqa: F401 prevent unused error
+from docker_for_galaxy import galaxy_service
 
 from ephemeris.shed_tools import InstallRepositoryManager
 
@@ -20,9 +20,8 @@ from ephemeris.shed_tools import InstallRepositoryManager
 class TestMiscellaneous(object):
     """This class is for miscellaneous tests that can use the same galaxy container"""
 
-    def test_invalid_keys_in_repo_list(self, caplog, start_container):  # noqa: F811 Prevent start_container unused warning.
-        container = start_container
-        irm = InstallRepositoryManager(container.gi)
+    def test_invalid_keys_in_repo_list(self, caplog, galaxy_service):
+        irm = InstallRepositoryManager(galaxy_service.api)
         caplog.set_level(logging.WARNING)
         irm.install_repositories([
             dict(name="bwa",
@@ -33,9 +32,8 @@ class TestMiscellaneous(object):
         assert "'sesame_ouvre_toi' not a valid key. Will be skipped during parsing" in caplog.text
 
     @pytest.mark.parametrize("parallel_tests", [1, 2])
-    def test_tool_tests(self, caplog, start_container, parallel_tests):  # noqa: F811
-        container = start_container
-        irm = InstallRepositoryManager(container.gi)
+    def test_tool_tests(self, caplog, galaxy_service, parallel_tests):
+        irm = InstallRepositoryManager(galaxy_service.api)
         caplog.set_level(logging.WARNING)
         repos = [{'name': 'collection_element_identifiers', 'owner': 'iuc', 'tool_panel_section_label': "NGS: Alignment"}]
         log = logging.getLogger()

--- a/tox.ini
+++ b/tox.ini
@@ -1,43 +1,29 @@
 # TODO: implement doc linting
 [tox]
-envlist = py{36}-lint, py{36}-pytest, py{36}, py{36}-integration
-source_dir = src/ephemeris
-test_dir = tests
+envlist = lint, pytest, integration
 
-[testenv]
-commands = {envpython} setup.py nosetests []
-whitelist_externals = bash
-
-[testenv:py36-lint]
-commands = flake8 {[tox]source_dir} {[tox]test_dir}
+[testenv:lint]
+commands = flake8 src/ephemeris tests
 skip_install = True
 deps =
     flake8
     flake8-import-order
 
-[testenv:py36-pytest]
+[testenv:pytest]
 deps =
     -r requirements.txt
     pytest
-    pytest-cov
     coverage
     codacy-coverage
     docker
-whitelist_externals = sed
-                      bash
 commands =
-    pytest -v --cov={envsitepackagesdir}/ephemeris --cov-report xml {[tox]test_dir}
-    # Replace the installed package directory by the source directory.
-    # This is needed for codacy to understand which files have coverage testing
-    # Unfortunately this has to run in the tox env to have access to envsitepackagesdir
-    sed -i 's#{envsitepackagesdir}#src#' coverage.xml
+    coverage run --source=ephemeris -m pytest -v tests
+    coverage xml
+    coverage html
+    coverage report
 
-[testenv:py36]
+[testenv:integration]
 deps =
     -r requirements.txt
-commands = bash {[tox]test_dir}/test.sh
-
-[testenv:py36-integration]
-deps =
-    -r requirements.txt
-commands = bash {[tox]test_dir}/test.sh
+whitelist_externals = bash
+commands = bash tests/test.sh


### PR DESCRIPTION
This simplifies using tox with any version of python, which is convenient.

Also I made an attempt to get a 'quicker' galaxy. I made a [galaxy-compose](https://github.com/LUMC/docker-galaxy-compose) image which is basically a refactoring of the galaxy-k8s image for docker compose setups. Due to starting a postgres, nginx and galaxy container simultaneously the startup time is improved and testing can commence earlier. This shaves 50 seconds of the testing (7m20 ->6m30). 

The galaxy-compose image can easily be updated to newer versions of galaxy and is therefore quite suitable for testing. Images are build weekly.