### PR TITLE
Add option to `shed-tools test` for specifying a history name

### DIFF
--- a/src/ephemeris/shed_tools.py
+++ b/src/ephemeris/shed_tools.py
@@ -230,7 +230,7 @@ class InstallRepositoryManager(object):
                    log=None,
                    test_user_api_key=None,
                    test_user="ephemeris@galaxyproject.org",
-                   test_history=None,
+                   test_history_name=None,
                    parallel_tests=1,
                    test_all_versions=False,
                    client_test_config_path=None,
@@ -240,8 +240,6 @@ class InstallRepositoryManager(object):
         tool_test_start = dt.datetime.now()
         tests_passed = []
         test_exceptions = []
-        test_history_name = test_history
-        test_history = None
 
         if not repositories:  # If repositories is None or empty list
             # Consider a variant of this that doesn't even consume a tool list YAML? target
@@ -636,7 +634,7 @@ def main():
             log=log,
             test_user_api_key=args.test_user_api_key,
             test_user=args.test_user,
-            test_history=args.test_history,
+            test_history_name=args.test_history_name,
             parallel_tests=args.parallel_tests,
             test_all_versions=args.test_all_versions,
             client_test_config_path=args.client_test_config,

--- a/src/ephemeris/shed_tools_args.py
+++ b/src/ephemeris/shed_tools_args.py
@@ -227,11 +227,11 @@ def parser():
              "user will be created if needed."
     )
     test_command_parser.add_argument(
-        "--test_history",
-        dest="test_history",
+        "--test_history_name",
+        dest="test_history_name",
         default=None,
         help="Use existing history or create history with provided name if none exists. "
-             "If --test_history is not set, a new history with a default name will always "
+             "If --test_history_name is not set, a new history with a default name will always "
              "be created. If multiple histories match the provided name, the first (newest) "
              "one returned by the Galaxy API will be selected."
     )


### PR DESCRIPTION
If at least one history with a matching name exists, the newest one will be used. If no existing history matches, one will be created with the specified name. If the option is not specified, the default (from `galaxy.tool_util.verify.interactor:GalaxyInteractorApi.new_history()`, currently `test_history`) will be used.