### PR TITLE
use class Indenter to fix wrong indentation in yaml output

### DIFF
--- a/src/ephemeris/generate_tool_list_from_ga_workflow_files.py
+++ b/src/ephemeris/generate_tool_list_from_ga_workflow_files.py
@@ -78,9 +78,14 @@ def extract_tool_shed_repositories_from_workflow_dict(workflow_dictionary):
 
 
 def print_yaml_tool_list(tool_dictionary, output_file):
+    class Indenter(yaml.Dumper):
+
+        def increase_indent(self, flow=False, indentless=False):
+            return super(Indenter, self).increase_indent(flow, False)
+
     with open(output_file, 'w') as F:
         F.write("\n".join([INSTALL_TOOL_DEPENDENCIES, INSTALL_REPOSITORY_DEPENDENCIES, INSTALL_RESOLVER_DEPENDENCIES, "", ""]))
-        F.write(yaml.safe_dump(tool_dictionary, default_flow_style=False))
+        F.write(yaml.safe_dump(tool_dictionary, Dumper=Indenter, default_flow_style=False))
     return
 
 


### PR DESCRIPTION
Testing this improvement in generate_tool_list_from_ga_workflow_files.py