### PR TITLE
Set Library Permissions

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -7,7 +7,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        python-version: ['3.6']
+        python-version: ['3.7']
         tox-action:
           - lint
           - pytest
@@ -37,7 +37,7 @@ jobs:
           submodules: true
       - uses: actions/setup-python@v1
         with:
-          python-version: '3.6'
+          python-version: '3.7'
       - name: Install dependencies
         run: |
           python3 -m pip install --upgrade pip setuptools

--- a/requirements.txt
+++ b/requirements.txt
@@ -5,3 +5,4 @@ Jinja2
 galaxy-tool-util>=20.9.1
 galaxy-util>=20.9.0
 pysam
+rich

--- a/setup.py
+++ b/setup.py
@@ -37,6 +37,7 @@ ENTRY_POINTS = '''
         setup-data-libraries=ephemeris.setup_data_libraries:main
         galaxy-wait=ephemeris.sleep:main
         install_tool_deps=ephemeris.install_tool_deps:main
+        set_library_permissions=ephemeris.set_library_permissions:main
 '''
 PACKAGE_DATA = {
     # Be sure to update MANIFEST.in for source dist.

--- a/setup.py
+++ b/setup.py
@@ -77,6 +77,7 @@ setup(
     install_requires=requirements,
     license="AFL",
     zip_safe=False,
+    python_requires=">=3.7",
     keywords='galaxy',
     classifiers=[
         'Development Status :: 5 - Production/Stable',
@@ -91,6 +92,8 @@ setup(
         "Programming Language :: Python :: 3",
         'Programming Language :: Python :: 3.7',
         'Programming Language :: Python :: 3.8',
+        'Programming Language :: Python :: 3.9',
+        'Programming Language :: Python :: 3.10',
     ],
     test_suite=TEST_DIR,
     tests_require=test_requirements

--- a/setup.py
+++ b/setup.py
@@ -89,7 +89,6 @@ setup(
         'Topic :: Software Development :: Testing',
         'Natural Language :: English',
         "Programming Language :: Python :: 3",
-        'Programming Language :: Python :: 3.6',
         'Programming Language :: Python :: 3.7',
         'Programming Language :: Python :: 3.8',
     ],

--- a/src/ephemeris/set_library_permissions.py
+++ b/src/ephemeris/set_library_permissions.py
@@ -121,10 +121,8 @@ def main():
         )
     set_permissions(gi, library_id=args.library, role_ids=args.roles, auto=args.yes)
     log.info(
-        "\nThis command script uses bioblend galaxyAPI to set ALL permissions of ALL datasets"
-    )
-    log.info(
-        "in given library to given roles. Be careful and cancel with Crtl+C if unsure.\n"
+        "\nThis script uses bioblend to update ALL permissions of ALL datasets in a"
+        "specified library to the given roles. Be careful and cancel if unsure\n"
     )
 
 

--- a/src/ephemeris/set_library_permissions.py
+++ b/src/ephemeris/set_library_permissions.py
@@ -1,8 +1,8 @@
 #!/usr/bin/env python
 """Tool to set permissions for all datasets of a given Galaxy Data Library"""
 
-import sys
 import argparse
+import sys
 import logging as log
 
 from bioblend import galaxy

--- a/src/ephemeris/set_library_permissions.py
+++ b/src/ephemeris/set_library_permissions.py
@@ -1,0 +1,100 @@
+#!/usr/bin/env python
+'''Tool to set permissions for all datasets of a given Galaxy Data Library'''
+
+import argparse
+import logging as log
+from bioblend import galaxy
+import sys, time, os
+
+from .common_parser import get_common_args
+# Print iterations progress
+def printProgressBar (iteration, total, prefix = '', suffix = '', decimals = 1, length = 100, fill = '█', printEnd = "\r"):
+    """
+    Call in a loop to create terminal progress bar
+    @params:
+        iteration   - Required  : current iteration (Int)
+        total       - Required  : total iterations (Int)
+        prefix      - Optional  : prefix string (Str)
+        suffix      - Optional  : suffix string (Str)
+        decimals    - Optional  : positive number of decimals in percent complete (Int)
+        length      - Optional  : character length of bar (Int)
+        fill        - Optional  : bar fill character (Str)
+        printEnd    - Optional  : end character (e.g. "\r", "\r\n") (Str)
+    """
+    percent = ("{0:." + str(decimals) + "f}").format(100 * (iteration / float(total)))
+    filledLength = int(length * iteration // total)
+    bar = fill * filledLength + '-' * (length - filledLength)
+    print(f'\r{prefix} |{bar}| {percent}% {suffix}', end = printEnd)
+    # Print New Line on Complete
+    if iteration == total: 
+        print()
+
+def get_datasets(gi, library_id) -> [str]:
+    objects = gi.libraries.show_dataset(library_id=library_id, dataset_id='')
+    datasets = []
+    for index in range(len(objects)):
+       if objects[index]['type'] == 'file':
+           datasets.append(objects[index]['id'])
+    if datasets == []:
+        sys.exit("No datasets in library!")
+    else:
+        return datasets
+
+def set_permissions(gi, library_id, role_ids):
+    log.info("Your library_id is " + library_id + "\n")
+    role_msg = "Your roles are: " + " ".join(role_ids)
+    log.info(role_msg)
+    datasets = get_datasets(gi, library_id)
+    total = len(datasets)
+    est = total*3/60
+    # Give User time to abort
+    log.info('\nSuccess! %d datasets found. Processing can take up to %f min', total, est)
+    t = 5
+    while t:
+        log.info('Starting in %d s ... Press Crtl+C to abort.', t)
+        time.sleep(1)
+        t -= 1
+    # Process datasets
+    for item in datasets:
+        current = datasets.index(item) + 1
+        log.debug('Processing dataset %d of %d, ID=%s', current, total, item)
+        rows, columns = os.popen('stty size', 'r').read().split()
+        printProgressBar(iteration=current, total=total, length=(int(columns) - 3))
+        gi.libraries.set_dataset_permissions(dataset_id=item, access_in=role_ids, modify_in=role_ids, manage_in=role_ids)  
+
+def _parser():
+    '''Constructs the parser object'''
+    parent = get_common_args()
+    parser = argparse.ArgumentParser(
+        parents=[parent],
+        description='Populate the Galaxy data library with data.'
+    )
+    parser.add_argument('--library', help="Specify the data library ID")
+    parser.add_argument('--roles', help="Specify a list of comma separated role IDs")
+    return parser
+
+def main():
+    print("\nThis command script uses bioblend galaxyAPI to set ALL permissions of ALL datasets")
+    print("in given library to given roles. Be careful and cancel with Crtl+C if unsure.\n")
+    args = _parser().parse_args()
+    if args.user and args.password:
+        gi = galaxy.GalaxyInstance(url=args.galaxy, email=args.user, password=args.password)
+    elif args.api_key:
+        gi = galaxy.GalaxyInstance(url=args.galaxy, key=args.api_key)
+    else:
+        sys.exit('Please specify either a valid Galaxy username/password or an API key.')
+
+    if args.verbose:
+        log.basicConfig(level=log.DEBUG)
+    else:
+        log.basicConfig(level=log.INFO)
+    
+    if args.roles and args.library:
+        args.roles = [r.strip() for r in args.roles.split(",")]
+    else:
+        sys.exit("Specify library ID (--library myLibraryID) and (list of) role(s) (--roles roleId1,roleId2)")
+    set_permissions(gi, library_id=args.library, role_ids=args.roles)
+
+
+if __name__ == '__main__':
+    main()

--- a/src/ephemeris/set_library_permissions.py
+++ b/src/ephemeris/set_library_permissions.py
@@ -74,7 +74,7 @@ def _parser():
     parser = argparse.ArgumentParser(
         parents=[parent], description="Populate the Galaxy data library with data."
     )
-    parser.add_argument("--library", help="Specify the data library ID")
+    parser.add_argument("library", help="Specify the data library ID")
     parser.add_argument("--roles", nargs="+", help="Specify a list of comma separated role IDs")
     parser.add_argument(
         "-y",

--- a/src/ephemeris/set_library_permissions.py
+++ b/src/ephemeris/set_library_permissions.py
@@ -1,11 +1,13 @@
 #!/usr/bin/env python
 """Tool to set permissions for all datasets of a given Galaxy Data Library"""
 
+import sys
 import argparse
 import logging as log
+
 from bioblend import galaxy
-import sys
 from rich.progress import Progress
+
 from .common_parser import get_common_args
 
 # Print iterations progress

--- a/src/ephemeris/set_library_permissions.py
+++ b/src/ephemeris/set_library_permissions.py
@@ -1,70 +1,110 @@
 #!/usr/bin/env python
-'''Tool to set permissions for all datasets of a given Galaxy Data Library'''
+"""Tool to set permissions for all datasets of a given Galaxy Data Library"""
 
 import argparse
 import logging as log
 from bioblend import galaxy
-import sys, time, os
+import sys
 from rich.progress import Progress
 from .common_parser import get_common_args
+
 # Print iterations progress
 
 
 def get_datasets(gi, library_id) -> [str]:
-    objects = gi.libraries.show_dataset(library_id=library_id, dataset_id='')
+    objects = gi.libraries.show_dataset(library_id=library_id, dataset_id="")
     datasets = []
     for index in range(len(objects)):
-       if objects[index]['type'] == 'file':
-           datasets.append(objects[index]['id'])
+        if objects[index]["type"] == "file":
+            datasets.append(objects[index]["id"])
     if datasets == []:
         sys.exit("No datasets in library!")
     else:
         return datasets
+
 
 def set_permissions(gi, library_id, role_ids, auto):
     log.info("Your library_id is " + library_id + "\n")
     log.info("Your roles are: %s", " ".join(role_ids))
     datasets = get_datasets(gi, library_id)
     total = len(datasets)
-    est = total*3/60
+    est = total * 3 / 60
     # Give User time to abort
-    log.info('\nSuccess! %d datasets found. Processing can take up to %0.02f min\n', total, est)
+    log.info(
+        "\nSuccess! %d datasets found. Processing can take up to %0.02f min\n",
+        total,
+        est,
+    )
     if auto:
         for current in range(total):
-            log.debug('Processing dataset %d of %d, ID=%s', current, total, datasets[current])
-            gi.libraries.set_dataset_permissions(dataset_id=datasets[current], access_in=role_ids, modify_in=role_ids, manage_in=role_ids)  
+            log.debug(
+                "Processing dataset %d of %d, ID=%s", current, total, datasets[current]
+            )
+            gi.libraries.set_dataset_permissions(
+                dataset_id=datasets[current],
+                access_in=role_ids,
+                modify_in=role_ids,
+                manage_in=role_ids,
+            )
     else:
         if input("Do you want to continue? (y/n) ") == "y":
             with Progress() as progress:
                 task = progress.add_task("[green]Processing datasets...", total=total)
                 for current in range(total):
-                    log.debug('Processing dataset %d of %d, ID=%s', current, total, datasets[current])
-                    gi.libraries.set_dataset_permissions(dataset_id=datasets[current], access_in=role_ids, modify_in=role_ids, manage_in=role_ids)  
+                    log.debug(
+                        "Processing dataset %d of %d, ID=%s",
+                        current,
+                        total,
+                        datasets[current],
+                    )
+                    gi.libraries.set_dataset_permissions(
+                        dataset_id=datasets[current],
+                        access_in=role_ids,
+                        modify_in=role_ids,
+                        manage_in=role_ids,
+                    )
                     progress.update(task, advance=1)
         else:
             log.info("Operation cancelled by user. No changes were applied.\n")
+
+
 def _parser():
-    '''Constructs the parser object'''
+    """Constructs the parser object"""
     parent = get_common_args()
     parser = argparse.ArgumentParser(
-        parents=[parent],
-        description='Populate the Galaxy data library with data.'
+        parents=[parent], description="Populate the Galaxy data library with data."
     )
-    parser.add_argument('--library', help="Specify the data library ID")
-    parser.add_argument('--roles', help="Specify a list of comma separated role IDs")
-    parser.add_argument('-y', '--yes', default=False, action="store_true",
-        help="Set the -y flag for auto-accept and skip manual approvement")
-    parser.add_argument('-s', '--silent', default=False, action="store_true", help="sets loglevel to ERROR")
+    parser.add_argument("--library", help="Specify the data library ID")
+    parser.add_argument("--roles", help="Specify a list of comma separated role IDs")
+    parser.add_argument(
+        "-y",
+        "--yes",
+        default=False,
+        action="store_true",
+        help="Set the -y flag for auto-accept and skip manual approvement",
+    )
+    parser.add_argument(
+        "-s",
+        "--silent",
+        default=False,
+        action="store_true",
+        help="sets loglevel to ERROR",
+    )
     return parser
+
 
 def main():
     args = _parser().parse_args()
     if args.user and args.password:
-        gi = galaxy.GalaxyInstance(url=args.galaxy, email=args.user, password=args.password)
+        gi = galaxy.GalaxyInstance(
+            url=args.galaxy, email=args.user, password=args.password
+        )
     elif args.api_key:
         gi = galaxy.GalaxyInstance(url=args.galaxy, key=args.api_key)
     else:
-        sys.exit('Please specify either a valid Galaxy username/password or an API key.')
+        sys.exit(
+            "Please specify either a valid Galaxy username/password or an API key."
+        )
 
     if args.verbose:
         log.basicConfig(level=log.DEBUG)
@@ -72,14 +112,21 @@ def main():
         log.basicConfig(level=log.ERROR)
     else:
         log.basicConfig(level=log.INFO)
-    
+
     if args.roles and args.library:
         args.roles = [r.strip() for r in args.roles.split(",")]
     else:
-        sys.exit("Specify library ID (--library myLibraryID) and (list of) role(s) (--roles roleId1,roleId2)")
+        sys.exit(
+            "Specify library ID (--library myLibraryID) and (list of) role(s) (--roles roleId1,roleId2)"
+        )
     set_permissions(gi, library_id=args.library, role_ids=args.roles, auto=args.yes)
-    log.info("\nThis command script uses bioblend galaxyAPI to set ALL permissions of ALL datasets")
-    log.info("in given library to given roles. Be careful and cancel with Crtl+C if unsure.\n")
+    log.info(
+        "\nThis command script uses bioblend galaxyAPI to set ALL permissions of ALL datasets"
+    )
+    log.info(
+        "in given library to given roles. Be careful and cancel with Crtl+C if unsure.\n"
+    )
 
-if __name__ == '__main__':
+
+if __name__ == "__main__":
     main()

--- a/src/ephemeris/set_library_permissions.py
+++ b/src/ephemeris/set_library_permissions.py
@@ -29,21 +29,17 @@ def set_permissions(gi, library_id, role_ids):
     est = total*3/60
     # Give User time to abort
     log.info('\nSuccess! %d datasets found. Processing can take up to %f min', total, est)
-    t = 5
-    with Progress() as progress:
-        task_countdown = progress.add_task("[red]Starting in 5 seconds...", total=total)
-        t = 5
-        while t:
-            time.sleep(1)
-            t -= 1
-            progress.update(task_countdown, advance=1)
-    # Process datasets
-        task = progress.add_task("[green]Processing datasets...", total=total)
-        for current in range(total):
-            log.debug('Processing dataset %d of %d, ID=%s', current, total, datasets[current])
-            rows, columns = os.popen('stty size', 'r').read().split()
-            gi.libraries.set_dataset_permissions(dataset_id=datasets[current], access_in=role_ids, modify_in=role_ids, manage_in=role_ids)  
-            progress.update(task, advance=1)
+    if input("Do you want to continue? (y/n) ") == "y":
+        with Progress() as progress:
+            task = progress.add_task("[green]Processing datasets...", total=total)
+            for current in range(total):
+                log.debug('Processing dataset %d of %d, ID=%s', current, total, datasets[current])
+                rows, columns = os.popen('stty size', 'r').read().split()
+                gi.libraries.set_dataset_permissions(dataset_id=datasets[current], access_in=role_ids, modify_in=role_ids, manage_in=role_ids)
+                progress.update(task, advance=1)
+    else:
+        print()
+        log.info("Operation cancelled by user. No changes were applied.\n")
 
 def _parser():
     '''Constructs the parser object'''

--- a/src/ephemeris/set_library_permissions.py
+++ b/src/ephemeris/set_library_permissions.py
@@ -42,8 +42,7 @@ def get_datasets(gi, library_id) -> [str]:
 
 def set_permissions(gi, library_id, role_ids):
     log.info("Your library_id is " + library_id + "\n")
-    role_msg = "Your roles are: " + " ".join(role_ids)
-    log.info(role_msg)
+    log.info("Your roles are: %s", " ".join(role_ids))
     datasets = get_datasets(gi, library_id)
     total = len(datasets)
     est = total*3/60

--- a/src/ephemeris/set_library_permissions.py
+++ b/src/ephemeris/set_library_permissions.py
@@ -2,8 +2,8 @@
 """Tool to set permissions for all datasets of a given Galaxy Data Library"""
 
 import argparse
-import sys
 import logging as log
+import sys
 
 from bioblend import galaxy
 from rich.progress import Progress

--- a/src/ephemeris/set_library_permissions.py
+++ b/src/ephemeris/set_library_permissions.py
@@ -75,7 +75,7 @@ def _parser():
         parents=[parent], description="Populate the Galaxy data library with data."
     )
     parser.add_argument("--library", help="Specify the data library ID")
-    parser.add_argument("--roles", help="Specify a list of comma separated role IDs")
+    parser.add_argument("--roles", nargs="+", help="Specify a list of comma separated role IDs")
     parser.add_argument(
         "-y",
         "--yes",

--- a/src/ephemeris/set_library_permissions.py
+++ b/src/ephemeris/set_library_permissions.py
@@ -24,7 +24,7 @@ def get_datasets(gi, library_id) -> [str]:
 
 
 def set_permissions(gi, library_id, role_ids, auto):
-    log.info("Your library_id is " + library_id + "\n")
+    log.info("Your library_id is %s", library_id)
     log.info("Your roles are: %s", " ".join(role_ids))
     datasets = get_datasets(gi, library_id)
     total = len(datasets)

--- a/src/ephemeris/set_library_permissions.py
+++ b/src/ephemeris/set_library_permissions.py
@@ -21,7 +21,7 @@ def get_datasets(gi, library_id) -> [str]:
     else:
         return datasets
 
-def set_permissions(gi, library_id, role_ids):
+def set_permissions(gi, library_id, role_ids, auto):
     log.info("Your library_id is " + library_id + "\n")
     log.info("Your roles are: %s", " ".join(role_ids))
     datasets = get_datasets(gi, library_id)
@@ -30,9 +30,9 @@ def set_permissions(gi, library_id, role_ids):
     # Give User time to abort
     log.info('\nSuccess! %d datasets found. Processing can take up to %0.02f min\n', total, est)
     if auto:
-            for current in range(total):
-                log.debug('Processing dataset %d of %d, ID=%s', current, total, datasets[current])
-                gi.libraries.set_dataset_permissions(dataset_id=datasets[current], access_in=role_ids, modify_in=role_ids, manage_in=role_ids)  
+        for current in range(total):
+            log.debug('Processing dataset %d of %d, ID=%s', current, total, datasets[current])
+            gi.libraries.set_dataset_permissions(dataset_id=datasets[current], access_in=role_ids, modify_in=role_ids, manage_in=role_ids)  
     else:
         if input("Do you want to continue? (y/n) ") == "y":
             with Progress() as progress:

--- a/tox.ini
+++ b/tox.ini
@@ -1,6 +1,6 @@
 # TODO: implement doc linting
 [tox]
-envlist = py{36}-lint, py{36}-pytest, py{36}, py{36}-integration
+envlist = py{37}-lint, py{37}-pytest, py{37}, py{37}-integration
 source_dir = src/ephemeris
 test_dir = tests
 
@@ -8,14 +8,14 @@ test_dir = tests
 commands = {envpython} setup.py nosetests []
 whitelist_externals = bash
 
-[testenv:py36-lint]
+[testenv:py37-lint]
 commands = flake8 {[tox]source_dir} {[tox]test_dir}
 skip_install = True
 deps =
     flake8
     flake8-import-order
 
-[testenv:py36-pytest]
+[testenv:py37-pytest]
 deps =
     -r requirements.txt
     pytest
@@ -32,12 +32,12 @@ commands =
     # Unfortunately this has to run in the tox env to have access to envsitepackagesdir
     sed -i 's#{envsitepackagesdir}#src#' coverage.xml
 
-[testenv:py36]
+[testenv:py37]
 deps =
     -r requirements.txt
 commands = bash {[tox]test_dir}/test.sh
 
-[testenv:py36-integration]
+[testenv:py37-integration]
 deps =
     -r requirements.txt
 commands = bash {[tox]test_dir}/test.sh


### PR DESCRIPTION
I added a tool to set the permissions of ALL datasets in a given data library (in folders and subfolders) at once to the given roles.
It is a workaround for one point of this [Issue](https://github.com/galaxyproject/galaxy/issues/15007), I created.

Usage:
```
usage: set_library_permissions [-h] [-v] [-g GALAXY] [-u USER] [-p PASSWORD] [-a API_KEY] [--library LIBRARY] [--roles ROLES]
```

Currently the default loglevel is INFO. I don't have experience with this so please tell me if I should change it.