### PR TITLE
Rename configuration option removed in tox 4.0

### DIFF
--- a/tox.ini
+++ b/tox.ini
@@ -31,7 +31,7 @@ commands =
     # Replace the installed package directory by the source directory.
     # This is needed for codacy to understand which files have coverage testing
     # Unfortunately this has to run in the tox env to have access to envsitepackagesdir
-    sed -i 's#{envsitepackagesdir}#src#' coverage.xml
+    sed -i 's|{envsitepackagesdir}|src|' coverage.xml
 
 [testenv:py37]
 deps =

--- a/tox.ini
+++ b/tox.ini
@@ -6,7 +6,7 @@ test_dir = tests
 
 [testenv]
 commands = {envpython} setup.py nosetests []
-whitelist_externals = bash
+allowlist_externals = bash
 
 [testenv:py37-lint]
 commands = flake8 {[tox]source_dir} {[tox]test_dir}
@@ -23,8 +23,9 @@ deps =
     coverage
     codacy-coverage
     docker
-whitelist_externals = sed
-                      bash
+allowlist_externals =
+    sed
+    bash
 commands =
     pytest -v --cov={envsitepackagesdir}/ephemeris --cov-report xml {[tox]test_dir}
     # Replace the installed package directory by the source directory.


### PR DESCRIPTION
See https://tox.wiki/en/latest/changelog.html#deprecations-and-removals-4-0-0rc4