### PR TITLE
Prefer dashes instead of underscores in flags

### DIFF
--- a/src/ephemeris/common_parser.py
+++ b/src/ephemeris/common_parser.py
@@ -3,6 +3,21 @@
 import argparse
 
 
+class HideUnderscoresHelpFormatter(argparse.HelpFormatter):
+    def add_arguments(self, actions):
+        for action in actions:
+            action.option_strings = list(s for s in action.option_strings if "_" not in s)
+            self.add_argument(action)
+
+
+class RawDescriptionHideUnderscoresHelpFormatter(HideUnderscoresHelpFormatter, argparse.RawDescriptionHelpFormatter):
+    pass
+
+
+class ArgumentDefaultsHideUnderscoresHelpFormatter(HideUnderscoresHelpFormatter, argparse.ArgumentDefaultsHelpFormatter):
+    pass
+
+
 def get_common_args(login_required=True, log_file=False):
     parser = argparse.ArgumentParser(add_help=False)
     general_group = parser.add_argument_group("General options")
@@ -11,6 +26,7 @@ def get_common_args(login_required=True, log_file=False):
     )
     if log_file:
         general_group.add_argument(
+            "--log-file",
             "--log_file",
             dest="log_file",
             help="Where the log file should be stored. "
@@ -31,6 +47,7 @@ def get_common_args(login_required=True, log_file=False):
         con_group.add_argument("-p", "--password", help="Password for the Galaxy user")
         con_group.add_argument(
             "-a",
+            "--api-key",
             "--api_key",
             dest="api_key",
             help="Galaxy admin user API key (required if not defined in the tools list file)",

--- a/src/ephemeris/generate_tool_list_from_ga_workflow_files.py
+++ b/src/ephemeris/generate_tool_list_from_ga_workflow_files.py
@@ -1,10 +1,7 @@
 #!/usr/bin/env python
 """Tool to generate tools from workflows"""
 import json
-from argparse import (
-    ArgumentParser,
-    RawDescriptionHelpFormatter,
-)
+from argparse import ArgumentParser
 from typing import (
     Iterable,
     List,
@@ -12,6 +9,7 @@ from typing import (
 
 import yaml
 
+from .common_parser import RawDescriptionHideUnderscoresHelpFormatter
 from .shed_tools import InstallRepoDict
 from .shed_tools_methods import format_tool_shed_url
 
@@ -30,7 +28,7 @@ def _parse_cli_options():
 
 def _parser():
     parser = ArgumentParser(
-        formatter_class=RawDescriptionHelpFormatter,
+        formatter_class=RawDescriptionHideUnderscoresHelpFormatter,
         usage="%(prog)s <options>",
         epilog="Workflow files must have been exported from Galaxy release 16.04 or newer.\n\n"
         "example:\n"
@@ -55,6 +53,7 @@ def _parser():
     )
     parser.add_argument(
         "-l",
+        "--panel-label",
         "--panel_label",
         dest="panel_label",
         default="Tools from workflows",

--- a/src/ephemeris/get_tool_list_from_galaxy.py
+++ b/src/ephemeris/get_tool_list_from_galaxy.py
@@ -1,10 +1,7 @@
 #!/usr/bin/env python
 """Tool to extract a tool list from galaxy."""
 
-from argparse import (
-    ArgumentDefaultsHelpFormatter,
-    ArgumentParser,
-)
+from argparse import ArgumentParser
 from distutils.version import StrictVersion
 
 import yaml
@@ -12,7 +9,10 @@ from bioblend.galaxy.tools import ToolClient
 from bioblend.galaxy.toolshed import ToolShedClient
 
 from . import get_galaxy_connection
-from .common_parser import get_common_args
+from .common_parser import (
+    ArgumentDefaultsHideUnderscoresHelpFormatter,
+    get_common_args,
+)
 from .shed_tools_methods import format_tool_shed_url
 
 
@@ -245,7 +245,7 @@ def _parser():
     """Creates the parser object."""
     parent = get_common_args(login_required=True)
     parser = ArgumentParser(
-        parents=[parent], formatter_class=ArgumentDefaultsHelpFormatter
+        parents=[parent], formatter_class=ArgumentDefaultsHideUnderscoresHelpFormatter
     )
     parser.add_argument(
         "-o",
@@ -255,6 +255,7 @@ def _parser():
         help="tool_list.yml output file",
     )
     parser.add_argument(
+        "--include-tool-panel-id",
         "--include_tool_panel_id",
         action="store_true",
         help="Include tool_panel_id in tool_list.yml ? "
@@ -262,11 +263,13 @@ def _parser():
         "https://github.com/galaxyproject/ansible-galaxy-tools/blob/master/files/tool_list.yaml.sample",
     )
     parser.add_argument(
+        "--skip-tool-panel-name",
         "--skip_tool_panel_name",
         action="store_true",
         help="Do not include tool_panel_name in tool_list.yml ?",
     )
     parser.add_argument(
+        "--skip-changeset-revision",
         "--skip_changeset_revision",
         action="store_true",
         help="Do not include the changeset revision when generating the tool list."
@@ -274,11 +277,13 @@ def _parser():
         "your galaxy instance using shed-install.",
     )
     parser.add_argument(
+        "--get-data-managers",
         "--get_data_managers",
         action="store_true",
         help="Include the data managers in the tool list. Requires admin login details",
     )
     parser.add_argument(
+        "--get-all-tools",
         "--get_all_tools",
         action="store_true",
         help="Get all tools and revisions, not just those which are present on the web ui."

--- a/src/ephemeris/install_tool_deps.py
+++ b/src/ephemeris/install_tool_deps.py
@@ -10,14 +10,17 @@ from bioblend import ConnectionError as ConnErr
 from bioblend.galaxy.tools import ToolClient
 
 from ephemeris import get_galaxy_connection
-from ephemeris.common_parser import get_common_args
+from ephemeris.common_parser import (
+    get_common_args,
+    HideUnderscoresHelpFormatter,
+)
 
 timeout_codes = (408, 502, 504)
 
 
 def _parser():
     parent = get_common_args()
-    parser = argparse.ArgumentParser(parents=[parent])
+    parser = argparse.ArgumentParser(parents=[parent], formatter_class=HideUnderscoresHelpFormatter)
     parser.add_argument(
         "-t",
         "--tool",

--- a/src/ephemeris/run_data_managers.py
+++ b/src/ephemeris/run_data_managers.py
@@ -37,7 +37,10 @@ from . import (
     get_galaxy_connection,
     load_yaml_file,
 )
-from .common_parser import get_common_args
+from .common_parser import (
+    get_common_args,
+    HideUnderscoresHelpFormatter,
+)
 from .ephemeris_log import (
     disable_external_library_logging,
     setup_global_logger,
@@ -320,6 +323,7 @@ def _parser():
 
     parser = argparse.ArgumentParser(
         parents=[parent],
+        formatter_class=HideUnderscoresHelpFormatter,
         description="Running Galaxy data managers in a defined order with defined parameters."
         "'watch_tool_data_dir' in galaxy config should be set to true.'",
     )
@@ -334,6 +338,7 @@ def _parser():
         help="Disables checking whether the item already exists in the tool data table.",
     )
     parser.add_argument(
+        "--ignore-errors",
         "--ignore_errors",
         action="store_true",
         help="Do not stop running when jobs have failed.",

--- a/src/ephemeris/set_library_permissions.py
+++ b/src/ephemeris/set_library_permissions.py
@@ -9,7 +9,10 @@ from typing import List
 from bioblend import galaxy
 from rich.progress import Progress
 
-from .common_parser import get_common_args
+from .common_parser import (
+    get_common_args,
+    HideUnderscoresHelpFormatter,
+)
 
 # Print iterations progress
 
@@ -75,7 +78,9 @@ def _parser():
     """Constructs the parser object"""
     parent = get_common_args()
     parser = argparse.ArgumentParser(
-        parents=[parent], description="Populate the Galaxy data library with data."
+        parents=[parent],
+        formatter_class=HideUnderscoresHelpFormatter,
+        description="Populate the Galaxy data library with data."
     )
     parser.add_argument("library", help="Specify the data library ID")
     parser.add_argument(

--- a/src/ephemeris/setup_data_libraries.py
+++ b/src/ephemeris/setup_data_libraries.py
@@ -8,7 +8,10 @@ import time
 import yaml
 from bioblend import galaxy
 
-from .common_parser import get_common_args
+from .common_parser import (
+    get_common_args,
+    HideUnderscoresHelpFormatter,
+)
 
 
 def create_legacy(gi, desc):
@@ -211,7 +214,9 @@ def _parser():
     """Constructs the parser object"""
     parent = get_common_args()
     parser = argparse.ArgumentParser(
-        parents=[parent], description="Populate the Galaxy data library with data."
+        parents=[parent],
+        formatter_class=HideUnderscoresHelpFormatter,
+        description="Populate the Galaxy data library with data."
     )
     parser.add_argument("-i", "--infile", required=True, type=argparse.FileType("r"))
     parser.add_argument(

--- a/src/ephemeris/shed_tools_args.py
+++ b/src/ephemeris/shed_tools_args.py
@@ -2,7 +2,10 @@
 
 import argparse
 
-from .common_parser import get_common_args
+from .common_parser import (
+    get_common_args,
+    HideUnderscoresHelpFormatter,
+)
 
 
 def parser():
@@ -41,12 +44,14 @@ def parser():
         "install",
         help="This installs tools in Galaxy from the Tool Shed."
         "Use shed-tools install --help for more information",
+        formatter_class=HideUnderscoresHelpFormatter,
         parents=[common_arguments],
     )
     update_command_parser = subparsers.add_parser(
         "update",
         help="This updates all tools in Galaxy to the latest revision. "
         "Use shed-tools update --help for more information",
+        formatter_class=HideUnderscoresHelpFormatter,
         parents=[common_arguments],
     )
 
@@ -54,6 +59,7 @@ def parser():
         "test",
         help="This tests the supplied list of tools in Galaxy. "
         "Use shed-tools test --help for more information",
+        formatter_class=HideUnderscoresHelpFormatter,
         parents=[common_arguments],
     )
 
@@ -71,12 +77,14 @@ def parser():
     ]:
         command_parser.add_argument(
             "-t",
+            "--tools-file",
             "--toolsfile",
             dest="tool_list_file",
             help="Tools file to use (see tool_list.yaml.sample)",
         )
         command_parser.add_argument(
             "-y",
+            "--yaml-tool",
             "--yaml_tool",
             dest="tool_yaml",
             help="Install tool represented by yaml string",
@@ -102,6 +110,7 @@ def parser():
             "(Only applicable if the tools file is not provided).",
         )
         command_parser.add_argument(
+            "--tool-shed",
             "--toolshed",
             dest="tool_shed_url",
             help="The Tool Shed URL where to install the tool from. "
@@ -113,6 +122,7 @@ def parser():
 
     for command_parser in [update_command_parser, install_command_parser]:
         command_parser.add_argument(
+            "--skip-install-tool-dependencies",
             "--skip_install_tool_dependencies",
             action="store_false",
             dest="install_tool_dependencies",
@@ -120,6 +130,7 @@ def parser():
             help=argparse.SUPPRESS,
         )  # Deprecated function. Leave for backwards compatibility.
         command_parser.add_argument(
+            "--install-tool-dependencies",
             "--install_tool_dependencies",
             action="store_true",
             dest="install_tool_dependencies",
@@ -127,6 +138,7 @@ def parser():
             "Can be overwritten on a per-tool basis in the tools file.",
         )
         command_parser.add_argument(
+            "--install-resolver-dependencies",
             "--install_resolver_dependencies",
             action="store_true",
             dest="install_resolver_dependencies",
@@ -134,6 +146,7 @@ def parser():
             help=argparse.SUPPRESS,
         )  # Deprecated function. Leave for backwards compatibility.
         command_parser.add_argument(
+            "--skip-install-resolver-dependencies",
             "--skip_install_resolver_dependencies",
             action="store_false",
             dest="install_resolver_dependencies",
@@ -142,6 +155,7 @@ def parser():
             "Can be overwritten on a per-tool basis in the tools file",
         )
         command_parser.add_argument(
+            "--skip-install-repository-dependencies",
             "--skip_install_repository_dependencies",
             action="store_false",
             dest="install_repository_dependencies",
@@ -154,12 +168,14 @@ def parser():
             help="Run tool tests on install tools, requires Galaxy 18.05 or newer.",
         )
         command_parser.add_argument(
+            "--test-existing",
             "--test_existing",
             action="store_true",
             help="If testing tools during install, also run tool tests on repositories already installed "
             "(i.e. skipped repositories).",
         )
         command_parser.add_argument(
+            "--test-json",
             "--test_json",
             dest="test_json",
             default="tool_test_output.json",
@@ -167,6 +183,7 @@ def parser():
             "This file can be turned into reports with ``planemo test_reports <output.json>``.",
         )
         command_parser.add_argument(
+            "--test-user-api-key",
             "--test_user_api_key",
             dest="test_user",
             help="If testing tools, a user is needed to execute the tests. "
@@ -175,6 +192,7 @@ def parser():
             "not need to be specified and --api_key will be reused.",
         )
         command_parser.add_argument(
+            "--test-user",
             "--test_user",
             dest="test_user",
             help="If testing tools, a user is needed to execute the tests. "
@@ -183,6 +201,7 @@ def parser():
             "user will be created if needed.",
         )
         command_parser.add_argument(
+            "--parallel-tests",
             "--parallel_tests",
             dest="parallel_tests",
             default=1,
@@ -200,6 +219,7 @@ def parser():
         "only applicable if the tools file is not provided).",
     )
     install_command_parser.add_argument(
+        "--section-label",
         "--section_label",
         default=None,
         dest="tool_panel_section_label",
@@ -218,6 +238,7 @@ def parser():
     # OPTIONS UNIQUE TO TEST
     # Same test_json as above but language modified for test instead of install/update.
     test_command_parser.add_argument(
+        "--test-json",
         "--test_json",
         default="tool_test_output.json",
         dest="test_json",
@@ -226,6 +247,7 @@ def parser():
     )
 
     test_command_parser.add_argument(
+        "--test-user-api-key",
         "--test_user_api_key",
         dest="test_user_api_key",
         help="A user is needed to execute the tests. "
@@ -234,6 +256,7 @@ def parser():
         "not need to be specified and --api_key will be reused.",
     )
     test_command_parser.add_argument(
+        "--test-user",
         "--test_user",
         dest="test_user",
         help="A user is needed to execute the tests. "
@@ -242,6 +265,7 @@ def parser():
         "user will be created if needed.",
     )
     test_command_parser.add_argument(
+        "--test-history-name",
         "--test_history_name",
         dest="test_history_name",
         default=None,
@@ -251,6 +275,7 @@ def parser():
         "one returned by the Galaxy API will be selected.",
     )
     test_command_parser.add_argument(
+        "--parallel-tests",
         "--parallel_tests",
         dest="parallel_tests",
         default=1,
@@ -258,6 +283,7 @@ def parser():
         help="Specify the maximum number of tests that will be run in parallel.",
     )
     test_command_parser.add_argument(
+        "--test-all-versions",
         "--test_all_versions",
         action="store_true",
         dest="test_all_versions",
@@ -266,6 +292,7 @@ def parser():
         "the --revisions arg, --tool_file or --tool_yaml.",
     )
     test_command_parser.add_argument(
+        "--client-test-config",
         "--client_test_config",
         dest="client_test_config",
         help="Annotate expectations about tools in client testing YAML "

--- a/src/ephemeris/sleep.py
+++ b/src/ephemeris/sleep.py
@@ -14,7 +14,10 @@ from argparse import ArgumentParser
 import requests
 from galaxy.util import unicodify
 
-from .common_parser import get_common_args
+from .common_parser import (
+    get_common_args,
+    HideUnderscoresHelpFormatter,
+)
 
 DEFAULT_SLEEP_WAIT = 1
 MESSAGE_KEY_NOT_YET_VALID = "[%02d] Provided key not (yet) valid... %s\n"
@@ -35,6 +38,7 @@ def _parser():
     parser = ArgumentParser(
         parents=[parent],
         usage="usage: %(prog)s <options>",
+        formatter_class=HideUnderscoresHelpFormatter,
         description="Script to sleep and wait for Galaxy to be alive.",
     )
     parser.add_argument(
@@ -44,9 +48,9 @@ def _parser():
         help="Galaxy startup timeout in seconds. The default value of 0 waits forever",
     )
     parser.add_argument(
-        "-a", "--api_key", dest="api_key", help="Sleep until key becomes available."
+        "-a", "--api-key", "--api_key", dest="api_key", help="Sleep until key becomes available."
     )
-    parser.add_argument("--ensure_admin", default=False, action="store_true")
+    parser.add_argument("--ensure-admin", "--ensure_admin", default=False, action="store_true")
     return parser
 
 

--- a/src/ephemeris/workflow_install.py
+++ b/src/ephemeris/workflow_install.py
@@ -5,7 +5,10 @@ import json
 import os
 
 from . import get_galaxy_connection
-from .common_parser import get_common_args
+from .common_parser import (
+    get_common_args,
+    HideUnderscoresHelpFormatter,
+)
 
 
 def import_workflow(gi, path, publish_wf=False):
@@ -24,14 +27,16 @@ def import_workflow(gi, path, publish_wf=False):
 
 def _parser():
     parent = get_common_args()
-    parser = argparse.ArgumentParser(parents=[parent])
+    parser = argparse.ArgumentParser(parents=[parent], formatter_class=HideUnderscoresHelpFormatter)
     parser.add_argument(
         "-w",
+        "--workflow-path",
         "--workflow_path",
         required=True,
         help='Path to a workflow file or a directory with multiple workflow files ending with ".ga"',
     )
     parser.add_argument(
+        "--publish-workflows",
         "--publish_workflows",
         required=False,
         action="store_true",


### PR DESCRIPTION
This converts all ephemeris command flags that use underscores to dashes instead. Underscores continue to be supported but are hidden from the help text.

Underscores in UNIX command line flags are pretty non-standard, and are way more painful to type, to boot.

Also, entry points for `install-tool-deps` and `set-library-permissions` are installed in addition to their original underscore versions. The underscore versions of these two commands should be considered deprecated maybe be removed at some point, but the underscore flags can be kept indefinitely with little harm.