### PR TITLE
Standardize CLI commands on - instead of _

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -37,7 +37,8 @@ ENTRY_POINTS = '''
         setup-data-libraries=ephemeris.setup_data_libraries:main
         galaxy-wait=ephemeris.sleep:main
         install_tool_deps=ephemeris.install_tool_deps:main
-        set_library_permissions=ephemeris.set_library_permissions:main
+        install-tool-deps=ephemeris.install_tool_deps:main
+        set-library-permissions=ephemeris.set_library_permissions:main
 '''
 PACKAGE_DATA = {
     # Be sure to update MANIFEST.in for source dist.


### PR DESCRIPTION
We have one new command waiting for a release (`set-library-permissions`) that was documented as using `-` in the CLI examples, and then `install-tool-deps` which used `_`, and now gets an alias for `-`