### PR TITLE
Remove folder id from get_folders function call in setup-data-libraries

### DIFF
--- a/src/ephemeris/setup_data_libraries.py
+++ b/src/ephemeris/setup_data_libraries.py
@@ -52,7 +52,7 @@ def create_legacy(gi, desc):
             if name:
                 # Check to see if the folder already exists, if it doesn't create it.
                 rmt_folder_list = []
-                folder = gi.libraries.get_folders(lib_id, folder_id)
+                folder = gi.libraries.get_folders(lib_id)
                 new_folder_name = "/" + name
                 if folder and not folder[0]["name"] == "/":
                     new_folder_name = folder[0]["name"] + "/" + name


### PR DESCRIPTION
- BioBlend [Release 1.1.0 ](https://github.com/galaxyproject/bioblend/commit/bdf7a10e37e505ac46b3480083d751b021fc208b)made the following change 

```
- Using the deprecated ``folder_id`` parameter of the
  ``LibraryClient.get_folders()`` method now raises a ``ValueError``
  exception."
```
- Therefore when the `setup-data-libraries` command is run ephemeris fails with the error message.

```
+ setup-data-libraries -g https://galaxy-example.org -a key --training -i /libraries/example-library.yaml --legacy
Library name: Mouse sequencing project
Traceback (most recent call last):
  File "/usr/local/bin/setup-data-libraries", line 8, in <module>
    sys.exit(main())
  File "/usr/local/lib/python3.10/dist-packages/ephemeris/setup_data_libraries.py", line 214, in main
    setup_data_libraries(gi, args.infile, training=args.training, legacy=args.legacy)
  File "/usr/local/lib/python3.10/dist-packages/ephemeris/setup_data_libraries.py", line 158, in setup_data_libraries
    jobs = list(create_func(gi, library_def))
  File "/usr/local/lib/python3.10/dist-packages/ephemeris/setup_data_libraries.py", line 84, in create_legacy
    populate_items(folder_id, desc)
  File "/usr/local/lib/python3.10/dist-packages/ephemeris/setup_data_libraries.py", line 62, in populate_items
    populate_items(folder_id, item)
  File "/usr/local/lib/python3.10/dist-packages/ephemeris/setup_data_libraries.py", line 51, in populate_items
    folder = gi.libraries.get_folders(lib_id, folder_id)
  File "/usr/local/lib/python3.10/dist-packages/bioblend/galaxy/libraries/__init__.py", line 295, in get_folders
    raise ValueError(
ValueError: The folder_id parameter has been removed, use the show_folder() method to view details of a folder for which you know the ID.
```
- Removing `folder_id` from the function call would fix the issue (I hope it's correct, when I manually changed it in my environment the command worked fine and I was able to see the `mouse genome` in the data libraries of my test Galaxy instance, just like it was described in the GTN [training material](https://training.galaxyproject.org/training-material/topics/admin/tutorials/data-library/tutorial.html#automatically-populating-a-data-library))