### PR TITLE
`shed_tools` add exit code

### DIFF
--- a/src/ephemeris/_idc_data_managers_to_tools.py
+++ b/src/ephemeris/_idc_data_managers_to_tools.py
@@ -93,11 +93,7 @@ def main():
     disable_external_library_logging()
     parser = _parser()
     args = parser.parse_args()
-    log = setup_global_logger(name=__name__, log_file=args.log_file)
-    if args.verbose:
-        log.setLevel(logging.DEBUG)
-    else:
-        log.setLevel(logging.INFO)
+    log = setup_global_logger(name=__name__, log_file=args.log_file, log_level=args.log_level)
     write_shed_install_conf(args.data_managers_conf, args.shed_install_output_conf)
 
 

--- a/src/ephemeris/_idc_split_data_manager_genomes.py
+++ b/src/ephemeris/_idc_split_data_manager_genomes.py
@@ -314,11 +314,7 @@ def main():
     disable_external_library_logging()
     parser = _parser()
     args = parser.parse_args()
-    log = setup_global_logger(name=__name__, log_file=args.log_file)
-    if args.verbose:
-        log.setLevel(logging.DEBUG)
-    else:
-        log.setLevel(logging.INFO)
+    log = setup_global_logger(name=__name__, log_file=args.log_file, log_level=args.log_level)
 
     if args.complete_check_cvmfs:
         is_build_complete = CVMFSPublishIsComplete(get_cvmfs_publish_records(args))

--- a/src/ephemeris/common_parser.py
+++ b/src/ephemeris/common_parser.py
@@ -27,13 +27,21 @@ def add_verbosity_argument(parser_or_group):
     parser_or_group.add_argument("-v", "--verbose", help="Increase output verbosity.", action="store_true")
 
 
-def add_log_file_argument(parser_or_group):
+def add_log_file_arguments(parser_or_group):
     parser_or_group.add_argument(
         "--log-file",
         "--log_file",
         dest="log_file",
-        help="Where the log file should be stored. " "Default is a file in your system's temp folder",
+        help="Where the log file should be stored. " "Default is a output to screen",
         default=None,
+    )
+    parser_or_group.add_argument(
+        "--log-level",
+        "--log_level",
+        dest="log_level",
+        choices=['DEBUG', 'INFO', 'WARNING', 'ERROR', 'CRITICAL'],
+        help="Level of debugging",
+        default='INFO',
     )
 
 
@@ -42,7 +50,7 @@ def get_common_args(login_required=True, log_file=False):
     general_group = parser.add_argument_group("General options")
     add_verbosity_argument(general_group)
     if log_file:
-        add_log_file_argument(general_group)
+        add_log_file_arguments(general_group)
 
     con_group = parser.add_argument_group("Galaxy connection")
     default_galaxy = os.environ.get("EPHEMERIS_GALAXY") or "http://localhost:8080"

--- a/src/ephemeris/ephemeris_log.py
+++ b/src/ephemeris/ephemeris_log.py
@@ -2,35 +2,6 @@ import logging
 import tempfile
 
 
-class ProgressConsoleHandler(logging.StreamHandler):
-    """
-    A handler class which allows the cursor to stay on
-    one line for selected messages
-    """
-
-    on_same_line = False
-
-    def emit(self, record):
-        try:
-            msg = self.format(record)
-            stream = self.stream
-            same_line = hasattr(record, "same_line")
-            if self.on_same_line and not same_line:
-                stream.write("\r\n")
-            stream.write(msg)
-            if same_line:
-                stream.write(".")
-                self.on_same_line = True
-            else:
-                stream.write("\r\n")
-                self.on_same_line = False
-            self.flush()
-        except (KeyboardInterrupt, SystemExit):
-            raise
-        except Exception:
-            self.handleError(record)
-
-
 def disable_external_library_logging():
     # Omit (most of the) logging by external libraries
     logging.getLogger("bioblend").setLevel(logging.ERROR)
@@ -41,23 +12,17 @@ def disable_external_library_logging():
         pass
 
 
-def setup_global_logger(name, log_file=None):
+def setup_global_logger(name, log_file=None, log_level='DEBUG'):
     formatter = logging.Formatter("%(asctime)s %(levelname)-5s - %(message)s")
-    progress = ProgressConsoleHandler()
-    console = logging.StreamHandler()
-    console.setFormatter(formatter)
-
+    
     logger = logging.getLogger(name)
-    logger.setLevel(logging.DEBUG)
-    logger.addHandler(progress)
+    logger.setLevel(getattr(logging, log_level))
 
     if not log_file:
-        # delete = false is chosen here because it is always nice to have a log file
-        # ready if you need to debug. Not having the "if only I had set a log file"
-        # moment after the fact.
-        temp = tempfile.NamedTemporaryFile(prefix="ephemeris_", delete=False)
-        log_file = temp.name
-    file_handler = logging.FileHandler(log_file)
-    logger.addHandler(file_handler)
-    logger.info(f"Storing log file in: {log_file}")
+        handler = logging.StreamHandler()
+    else:
+        handler = logging.FileHandler(log_file)
+    
+    handler.setFormatter(formatter)
+    logger.addHandler(handler)
     return logger

--- a/src/ephemeris/run_data_managers.py
+++ b/src/ephemeris/run_data_managers.py
@@ -371,11 +371,7 @@ def main(argv=None):
     disable_external_library_logging()
     parser = _parser()
     args = parser.parse_args(argv)
-    log = setup_global_logger(name=__name__, log_file=args.log_file)
-    if args.verbose:
-        log.setLevel(logging.DEBUG)
-    else:
-        log.setLevel(logging.INFO)
+    log = setup_global_logger(name=__name__, log_file=args.log_file, log_level=args.log_level)
     gi = get_galaxy_connection(args, file=args.config, log=log, login_required=True)
     config = load_yaml_file(args.config)
     data_managers = DataManagers(gi, config)

--- a/src/ephemeris/shed_tools.py
+++ b/src/ephemeris/shed_tools.py
@@ -694,14 +694,11 @@ def main(argv=None):
         tool_list = dict()
 
     # Get some of the other installation arguments
-    kwargs = dict(
-        default_install_tool_dependencies=tool_list.get("install_tool_dependencies")
-        or getattr(args, "install_tool_dependencies", False),
-        default_install_repository_dependencies=tool_list.get("install_repository_dependencies")
-        or getattr(args, "install_repository_dependencies", False),
-        default_install_resolver_dependencies=tool_list.get("install_resolver_dependencies")
-        or getattr(args, "install_resolver_dependencies", False),
-    )
+    kwargs = dict()
+    for k in ["default_install_tool_dependencies", "default_install_repository_dependencies", "default_install_resolver_dependencies"]:
+        kwargs[k] = tool_list.get(k)
+        if kwargs[k] is None:
+            getattr(args, k, False)
 
     # Start installing/updating and store the results in install_results.
     # Or do testing if the action is `test`


### PR DESCRIPTION
Having a meaningful exit code makes this much more usable in automatization (fixes https://github.com/galaxyproject/ephemeris/issues/217).

- Also add a `- add --log_level` argument. 
- Cleanup logging code
  - `ProgressConsoleHandler` seemed to be unused
  - log to screen / file should be sufficient