### PR TITLE
Add script to install or tabulate (singularity) containers

### DIFF
--- a/src/ephemeris/install_container.py
+++ b/src/ephemeris/install_container.py
@@ -1,8 +1,27 @@
 """
-install (i.e. cache) containers for a set of tools
+Install or tabulate (singularity) containers
 
-tools can be selected by basic string matching (--filter)
-or version (--latest)
+Use cases:
+
+1. run on the Galaxy machine itself and trigger caching of (singularity) containers
+2. determine a table that maps docker URIs and cached container image paths.
+   this table can then be used on machines that do not have access to CVMFS
+   to download container images.
+
+what the tool does:
+
+1. query the list of tools from an instance (optionaly filter by regexes on the tool_ids and latest version)
+2. for each tool:
+
+- resolve the container with the container resolvers that are configured at the target instance 
+  (for cached singularity containers with a configured cache directory this will yield a path)
+- if `--install_container` the resolver(s) will be called again with the install parameter set to `True`
+  (if the determined path does not exist)
+- if `--tabulate N` is used the `N`-th configured resolver is called and the result is printed together
+  with the tool_id and the path that was determined in the 1st step (tab separated).
+  The idea is that the instance configures a singularity container resolver (at index N) without a cache
+  directory defined. This resolver will yield the original container URI (docker://...). If this resolver
+  is defined after the cached / non-cached singularity container resolvers it should never be called in production.
 """
 
 import argparse
@@ -13,8 +32,8 @@ import re
 from typing import List
 
 from bioblend.galaxy import GalaxyInstance
-from bioblend.galaxy.tools import ToolClient
 from bioblend.galaxy.container_resolution import ContainerResolutionClient
+from bioblend.galaxy.tools import ToolClient
 from galaxy.tool_util.version import parse_version
 from galaxy.util.tool_version import remove_version_from_guid
 

--- a/src/ephemeris/install_container.py
+++ b/src/ephemeris/install_container.py
@@ -29,7 +29,10 @@ import logging
 import os
 import os.path
 import re
-from typing import Any, List
+from typing import (
+    Any,
+    List,
+)
 
 from bioblend.galaxy import GalaxyInstance
 from bioblend.galaxy.container_resolution import ContainerResolutionClient

--- a/src/ephemeris/install_container.py
+++ b/src/ephemeris/install_container.py
@@ -38,7 +38,7 @@ from galaxy.tool_util.version import parse_version
 from galaxy.util.tool_version import remove_version_from_guid
 
 
-def get_tool_list(galaxy_instance: GalaxyInstance, include: List[str], exclude: List[str], latest: bool):
+def get_tool_list(galaxy_instance: GalaxyInstance, include: List[str], exclude: List[str], latest: bool) -> list[str]:
     """
     get a list of tool IDs from a galaxy instance
 
@@ -47,7 +47,7 @@ def get_tool_list(galaxy_instance: GalaxyInstance, include: List[str], exclude: 
     tool_client = ToolClient(galaxy_instance)
     tools = tool_client.get_tools()
 
-    tool_versions = {}
+    tool_versions: dict[str, list[tuple[str, str]]] = {}
     for tool in tools:
         tool_id = tool["id"]
         if include and not any([re.search(f, tool_id) for f in include]):
@@ -126,7 +126,6 @@ galaxy_instance = GalaxyInstance(url=args.url, key=key)
 # get tools (matching filters and latest arguments)
 tool_list = get_tool_list(galaxy_instance, args.include, args.exclude, args.latest)
 
-new_containers = set()
 container_resolution_client = ContainerResolutionClient(galaxy_instance=galaxy_instance)
 
 resolvers = container_resolution_client.get_container_resolvers()

--- a/src/ephemeris/install_container.py
+++ b/src/ephemeris/install_container.py
@@ -17,11 +17,12 @@ what the tool does:
   (for cached singularity containers with a configured cache directory this will yield a path)
 - if `--install_container` the resolver(s) will be called again with the install parameter set to `True`
   (if the determined path does not exist)
-- if `--tabulate N` is used the `N`-th configured resolver is called and the result is printed together
-  with the tool_id and the path that was determined in the 1st step (tab separated).
-  The idea is that the instance configures a singularity container resolver (at index N) without a cache
+- if `--tabulate` is used the tool ids and the result of the container resolvers (the cached path)
+  will be printed comma separated
+  if in addition `--index N` is used the `N`-th configured resolver is called and the result is printed as additional
+  column. The idea is that the instance configures a singularity container resolver (at index N) without a cache
   directory defined. This resolver will yield the original container URI (docker://...). If this resolver
-  is defined after the cached / non-cached singularity container resolvers it should never be called in production.
+  is defined after the cached / non-cached singularity container resolvers it will never be called in production.
 """
 
 import argparse
@@ -100,7 +101,8 @@ parser.add_argument(
 )
 parser.add_argument("--latest", action="store_true", default=False, help="consider only the latest version of the tool")
 parser.add_argument("--install_container", action="store_true", default=False, help="install the container")
-parser.add_argument("--tabulate", type=int, action="store", required=False, default=None, help="resolver index")
+parser.add_argument("--tabulate", action="store_true", default=False, help="Tabulate tool_id and resolver results")
+parser.add_argument("--index", type=int, action="store", required=False, default=None, help="The index of an additional resolver to tabulate")
 parser.add_argument(
     "-log",
     "--loglevel",
@@ -131,10 +133,6 @@ tool_list = get_tool_list(galaxy_instance, args.include, args.exclude, args.late
 
 container_resolution_client = ContainerResolutionClient(galaxy_instance=galaxy_instance)
 
-resolvers = container_resolution_client.get_container_resolvers()
-for i, resolver in enumerate(resolvers):
-    logger.debug(f"{i=} {resolver=}")
-
 for tool in tool_list:
     logger.debug(f"Checking {tool}")
     res = container_resolution_client.resolve_toolbox(tool_ids=[tool])
@@ -149,13 +147,16 @@ for tool in tool_list:
         continue
 
     if args.tabulate:
-        res = container_resolution_client.resolve_toolbox(tool_ids=[tool], index=4)
-        container_uri = None
-        for i, r in enumerate(res):
-            logger.debug(f"{r=}")
-            tool_id = r["tool_id"]
-            container_uri = r["status"].get("environment_path")
-        print(f"{tool}\t{container}\t{container_uri}")
+        if args.index is None:
+            print(f"{tool}\t{container}")
+        else:
+            res = container_resolution_client.resolve_toolbox(tool_ids=[tool], index=args.index)
+            container_uri = None
+            for i, r in enumerate(res):
+                logger.debug(f"{r=}")
+                tool_id = r["tool_id"]
+                container_uri = r["status"].get("environment_path")
+            print(f"{tool}\t{container}\t{container_uri}")
 
     if args.install_container:
         if os.path.exists(container):

--- a/src/ephemeris/install_container.py
+++ b/src/ephemeris/install_container.py
@@ -14,7 +14,7 @@ from typing import List
 
 from bioblend.galaxy import GalaxyInstance
 from bioblend.galaxy.tools import ToolClient
-from bioblend.galaxy.container_resolution  import ContainerResolutionClient
+from bioblend.galaxy.container_resolution import ContainerResolutionClient
 from galaxy.tool_util.version import parse_version
 from galaxy.util.tool_version import remove_version_from_guid
 
@@ -27,7 +27,7 @@ def get_tool_list(galaxy_instance: GalaxyInstance, include: List[str], exclude: 
     """
     tool_client = ToolClient(galaxy_instance)
     tools = tool_client.get_tools()
-    
+
     tool_versions = {}
     for tool in tools:
         tool_id = tool["id"]
@@ -36,7 +36,7 @@ def get_tool_list(galaxy_instance: GalaxyInstance, include: List[str], exclude: 
         if exclude and any([re.search(f, tool_id) for f in exclude]):
             continue
         tool_id = remove_version_from_guid(tool_id) or tool_id
-    
+
         if tool_id not in tool_versions:
             tool_versions[tool_id] = []
         try:
@@ -54,35 +54,38 @@ def get_tool_list(galaxy_instance: GalaxyInstance, include: List[str], exclude: 
             tool_list.append(t[1])
     return tool_list
 
-parser = argparse.ArgumentParser(description='List / install containers')
-parser.add_argument('--url', type=str, action='store', required=True, default=None, help='Galaxy URL')
+
+parser = argparse.ArgumentParser(description="List / install containers")
+parser.add_argument("--url", type=str, action="store", required=True, default=None, help="Galaxy URL")
 parser.add_argument(
     "--key", type=str, action="store", required=False, default=None, help="API key, better set API_KEY env var"
 )
 parser.add_argument(
-    '--include',
+    "--include",
     type=str,
-    action='append',
+    action="append",
     dest="include",
     default=[],
-    help='include tool id by searching for regexp, if any filter applies a tool is included'
+    help="include tool id by searching for regexp, if any filter applies a tool is included",
 )
 parser.add_argument(
-    '--exclude',
+    "--exclude",
     type=str,
-    action='append',
+    action="append",
     dest="exclude",
     default=[],
-    help='filter tool id by searching for regexp, if any filter applies a tool is excluded'
+    help="filter tool id by searching for regexp, if any filter applies a tool is excluded",
 )
-parser.add_argument('--latest', action='store_true', default=False, help='consider only the latest version of the tool')
-parser.add_argument('--install_container', action='store_true', default=False, help='install the container')
-parser.add_argument('--tabulate', type=int, action='store', required=False, default=None, help='resolver index')
-parser.add_argument( '-log',
-                     '--loglevel',
-                     choices=['debug', 'info', 'warning', 'error'],
-                     default='warning',
-                     help='Provide logging level. Example --loglevel debug, default=warning' )
+parser.add_argument("--latest", action="store_true", default=False, help="consider only the latest version of the tool")
+parser.add_argument("--install_container", action="store_true", default=False, help="install the container")
+parser.add_argument("--tabulate", type=int, action="store", required=False, default=None, help="resolver index")
+parser.add_argument(
+    "-log",
+    "--loglevel",
+    choices=["debug", "info", "warning", "error"],
+    default="warning",
+    help="Provide logging level. Example --loglevel debug, default=warning",
+)
 args = parser.parse_args()
 
 logging.getLogger().setLevel(logging.WARNING)
@@ -95,17 +98,17 @@ handler = logging.StreamHandler()
 logger.addHandler(handler)
 
 # Add a formatter to the handler (optional)
-formatter = logging.Formatter('%(asctime)s - %(levelname)s - %(message)s')
+formatter = logging.Formatter("%(asctime)s - %(levelname)s - %(message)s")
 handler.setFormatter(formatter)
 
-key = os.environ.get('GALAXY_API_KEY', args.key)
+key = os.environ.get("GALAXY_API_KEY", args.key)
 galaxy_instance = GalaxyInstance(url=args.url, key=key)
 
 # get tools (matching filters and latest arguments)
 tool_list = get_tool_list(galaxy_instance, args.include, args.exclude, args.latest)
 
 new_containers = set()
-container_resolution_client = ContainerResolutionClient(galaxy_instance = galaxy_instance)
+container_resolution_client = ContainerResolutionClient(galaxy_instance=galaxy_instance)
 
 resolvers = container_resolution_client.get_container_resolvers()
 for i, resolver in enumerate(resolvers):
@@ -113,11 +116,11 @@ for i, resolver in enumerate(resolvers):
 
 for tool in tool_list:
     logger.debug(f"Checking {tool}")
-    res = container_resolution_client.resolve_toolbox(tool_ids = [tool])
+    res = container_resolution_client.resolve_toolbox(tool_ids=[tool])
     container = None
     for i, r in enumerate(res):
         logger.debug(f"{r=}")
-        tool_id = r['tool_id']
+        tool_id = r["tool_id"]
         container = r["status"].get("environment_path")
 
     if container is None:
@@ -125,22 +128,22 @@ for tool in tool_list:
         continue
 
     if args.tabulate:
-        res = container_resolution_client.resolve_toolbox(tool_ids = [tool], index=4)
+        res = container_resolution_client.resolve_toolbox(tool_ids=[tool], index=4)
         container_uri = None
         for i, r in enumerate(res):
             logger.debug(f"{r=}")
-            tool_id = r['tool_id']
+            tool_id = r["tool_id"]
             container_uri = r["status"].get("environment_path")
-        print(f"{tool}\t{container}\t{container_uri}")        
+        print(f"{tool}\t{container}\t{container_uri}")
 
     if args.install_container:
         if os.path.exists(container):
             logger.debug(f"Container for {tool} already installed {os.path.basename(container)}")
             continue
 
-        res = container_resolution_client.resolve_toolbox(tool_ids = [tool], install=args.install_container)
+        res = container_resolution_client.resolve_toolbox(tool_ids=[tool], install=args.install_container)
         for i, r in enumerate(res):
-            tool_id = r['tool_id']
+            tool_id = r["tool_id"]
             new_container = r["status"].get("environment_path")
 
             if new_container and os.path.exists(new_container):

--- a/src/ephemeris/install_container.py
+++ b/src/ephemeris/install_container.py
@@ -1,0 +1,149 @@
+"""
+install (i.e. cache) containers for a set of tools
+
+tools can be selected by basic string matching (--filter)
+or version (--latest)
+"""
+
+import argparse
+import logging
+import os
+import os.path
+import re
+from typing import List
+
+from bioblend.galaxy import GalaxyInstance
+from bioblend.galaxy.tools import ToolClient
+from bioblend.galaxy.container_resolution  import ContainerResolutionClient
+from galaxy.tool_util.version import parse_version
+from galaxy.util.tool_version import remove_version_from_guid
+
+
+def get_tool_list(galaxy_instance: GalaxyInstance, include: List[str], exclude: List[str], latest: bool):
+    """
+    get a list of tool IDs from a galaxy instance
+
+    include are applied and if desired only the latest version of each tool is returned
+    """
+    tool_client = ToolClient(galaxy_instance)
+    tools = tool_client.get_tools()
+    
+    tool_versions = {}
+    for tool in tools:
+        tool_id = tool["id"]
+        if include and not any([re.search(f, tool_id) for f in include]):
+            continue
+        if exclude and any([re.search(f, tool_id) for f in exclude]):
+            continue
+        tool_id = remove_version_from_guid(tool_id) or tool_id
+    
+        if tool_id not in tool_versions:
+            tool_versions[tool_id] = []
+        try:
+            version = parse_version(tool["version"])
+        except:
+            logger.error(f"could not parse version {version} of tool {tool}")
+            continue
+        tool_versions[tool_id].append((version, tool["id"]))
+    tool_list = []
+    for tool_id in tool_versions:
+        tool_versions[tool_id] = sorted(tool_versions[tool_id], reverse=True)
+        if latest:
+            tool_versions[tool_id] = tool_versions[tool_id][:1]
+        for t in tool_versions[tool_id]:
+            tool_list.append(t[1])
+    return tool_list
+
+parser = argparse.ArgumentParser(description='List / install containers')
+parser.add_argument('--url', type=str, action='store', required=True, default=None, help='Galaxy URL')
+parser.add_argument(
+    "--key", type=str, action="store", required=False, default=None, help="API key, better set API_KEY env var"
+)
+parser.add_argument(
+    '--include',
+    type=str,
+    action='append',
+    dest="include",
+    default=[],
+    help='include tool id by searching for regexp, if any filter applies a tool is included'
+)
+parser.add_argument(
+    '--exclude',
+    type=str,
+    action='append',
+    dest="exclude",
+    default=[],
+    help='filter tool id by searching for regexp, if any filter applies a tool is excluded'
+)
+parser.add_argument('--latest', action='store_true', default=False, help='consider only the latest version of the tool')
+parser.add_argument('--install_container', action='store_true', default=False, help='install the container')
+parser.add_argument('--tabulate', type=int, action='store', required=False, default=None, help='resolver index')
+parser.add_argument( '-log',
+                     '--loglevel',
+                     choices=['debug', 'info', 'warning', 'error'],
+                     default='warning',
+                     help='Provide logging level. Example --loglevel debug, default=warning' )
+args = parser.parse_args()
+
+logging.getLogger().setLevel(logging.WARNING)
+logger = logging.getLogger(__name__)
+# Set the log level for your logger to the desired level (e.g., INFO)
+logger.setLevel(args.loglevel.upper())
+
+# Create a handler for logging output (e.g., console handler)
+handler = logging.StreamHandler()
+logger.addHandler(handler)
+
+# Add a formatter to the handler (optional)
+formatter = logging.Formatter('%(asctime)s - %(levelname)s - %(message)s')
+handler.setFormatter(formatter)
+
+key = os.environ.get('GALAXY_API_KEY', args.key)
+galaxy_instance = GalaxyInstance(url=args.url, key=key)
+
+# get tools (matching filters and latest arguments)
+tool_list = get_tool_list(galaxy_instance, args.include, args.exclude, args.latest)
+
+new_containers = set()
+container_resolution_client = ContainerResolutionClient(galaxy_instance = galaxy_instance)
+
+resolvers = container_resolution_client.get_container_resolvers()
+for i, resolver in enumerate(resolvers):
+    logger.debug(f"{i=} {resolver=}")
+
+for tool in tool_list:
+    logger.debug(f"Checking {tool}")
+    res = container_resolution_client.resolve_toolbox(tool_ids = [tool])
+    container = None
+    for i, r in enumerate(res):
+        logger.debug(f"{r=}")
+        tool_id = r['tool_id']
+        container = r["status"].get("environment_path")
+
+    if container is None:
+        logger.debug(f"No container for for {tool}")
+        continue
+
+    if args.tabulate:
+        res = container_resolution_client.resolve_toolbox(tool_ids = [tool], index=4)
+        container_uri = None
+        for i, r in enumerate(res):
+            logger.debug(f"{r=}")
+            tool_id = r['tool_id']
+            container_uri = r["status"].get("environment_path")
+        print(f"{tool}\t{container}\t{container_uri}")        
+
+    if args.install_container:
+        if os.path.exists(container):
+            logger.debug(f"Container for {tool} already installed {os.path.basename(container)}")
+            continue
+
+        res = container_resolution_client.resolve_toolbox(tool_ids = [tool], install=args.install_container)
+        for i, r in enumerate(res):
+            tool_id = r['tool_id']
+            new_container = r["status"].get("environment_path")
+
+            if new_container and os.path.exists(new_container):
+                print(f"Installed {new_container}")
+            else:
+                logger.error(f"Could not install container for {tool} {container=} {new_container=}")

--- a/src/ephemeris/install_container.py
+++ b/src/ephemeris/install_container.py
@@ -32,7 +32,6 @@ import os.path
 import re
 from typing import (
     Any,
-    List,
     TYPE_CHECKING,
 )
 
@@ -43,13 +42,11 @@ from galaxy.tool_util.version import parse_version
 from galaxy.util.tool_version import remove_version_from_guid
 
 if TYPE_CHECKING:
-    from packaging.version import (
-        LegacyVersion,
-        Version,
-    )
+    from galaxy.tool_util.version import LegacyVersion
+    from packaging.version import Version
 
 
-def get_tool_list(galaxy_instance: GalaxyInstance, include: List[str], exclude: List[str], latest: bool) -> list[str]:
+def get_tool_list(galaxy_instance: GalaxyInstance, include: list[str], exclude: list[str], latest: bool) -> list[str]:
     """
     get a list of tool IDs from a galaxy instance
 

--- a/src/ephemeris/install_container.py
+++ b/src/ephemeris/install_container.py
@@ -64,7 +64,7 @@ def get_tool_list(galaxy_instance: GalaxyInstance, include: List[str], exclude: 
             tool_versions[tool_id] = []
         try:
             version = parse_version(tool["version"])
-        except:
+        except Exception:
             logger.error(f"could not parse version {version} of tool {tool}")
             continue
         tool_versions[tool_id].append((version, tool["id"]))

--- a/src/ephemeris/install_container.py
+++ b/src/ephemeris/install_container.py
@@ -13,7 +13,7 @@ what the tool does:
 1. query the list of tools from an instance (optionaly filter by regexes on the tool_ids and latest version)
 2. for each tool:
 
-- resolve the container with the container resolvers that are configured at the target instance 
+- resolve the container with the container resolvers that are configured at the target instance
   (for cached singularity containers with a configured cache directory this will yield a path)
 - if `--install_container` the resolver(s) will be called again with the install parameter set to `True`
   (if the determined path does not exist)
@@ -29,7 +29,7 @@ import logging
 import os
 import os.path
 import re
-from typing import List
+from typing import Any, List
 
 from bioblend.galaxy import GalaxyInstance
 from bioblend.galaxy.container_resolution import ContainerResolutionClient
@@ -47,7 +47,7 @@ def get_tool_list(galaxy_instance: GalaxyInstance, include: List[str], exclude: 
     tool_client = ToolClient(galaxy_instance)
     tools = tool_client.get_tools()
 
-    tool_versions: dict[str, list[tuple[str, str]]] = {}
+    tool_versions: dict[str, list[tuple[LegacyVersion | Version, Any]]] = {}
     for tool in tools:
         tool_id = tool["id"]
         if include and not any([re.search(f, tool_id) for f in include]):

--- a/src/ephemeris/install_container.py
+++ b/src/ephemeris/install_container.py
@@ -151,7 +151,7 @@ for tool in tool_list:
     logger.debug(f"Checking {tool}")
     res = container_resolution_client.resolve_toolbox(tool_ids=[tool])
     container = None
-    for i, r in enumerate(res):
+    for r in res:
         logger.debug(f"{r=}")
         tool_id = r["tool_id"]
         container = r["status"].get("environment_path")
@@ -166,7 +166,7 @@ for tool in tool_list:
         else:
             res = container_resolution_client.resolve_toolbox(tool_ids=[tool], index=args.index)
             container_uri = None
-            for i, r in enumerate(res):
+            for r in res:
                 logger.debug(f"{r=}")
                 tool_id = r["tool_id"]
                 container_uri = r["status"].get("environment_path")
@@ -178,7 +178,7 @@ for tool in tool_list:
             continue
 
         res = container_resolution_client.resolve_toolbox(tool_ids=[tool], install=args.install_container)
-        for i, r in enumerate(res):
+        for r in res:
             tool_id = r["tool_id"]
             new_container = r["status"].get("environment_path")
 

--- a/src/ephemeris/install_container.py
+++ b/src/ephemeris/install_container.py
@@ -33,6 +33,7 @@ import re
 from typing import (
     Any,
     List,
+    TYPE_CHECKING,
 )
 
 from bioblend.galaxy import GalaxyInstance
@@ -40,6 +41,12 @@ from bioblend.galaxy.container_resolution import ContainerResolutionClient
 from bioblend.galaxy.tools import ToolClient
 from galaxy.tool_util.version import parse_version
 from galaxy.util.tool_version import remove_version_from_guid
+
+if TYPE_CHECKING:
+    from packaging.version import (
+        LegacyVersion,
+        Version,
+    )
 
 
 def get_tool_list(galaxy_instance: GalaxyInstance, include: List[str], exclude: List[str], latest: bool) -> list[str]:
@@ -102,7 +109,14 @@ parser.add_argument(
 parser.add_argument("--latest", action="store_true", default=False, help="consider only the latest version of the tool")
 parser.add_argument("--install_container", action="store_true", default=False, help="install the container")
 parser.add_argument("--tabulate", action="store_true", default=False, help="Tabulate tool_id and resolver results")
-parser.add_argument("--index", type=int, action="store", required=False, default=None, help="The index of an additional resolver to tabulate")
+parser.add_argument(
+    "--index",
+    type=int,
+    action="store",
+    required=False,
+    default=None,
+    help="The index of an additional resolver to tabulate",
+)
 parser.add_argument(
     "-log",
     "--loglevel",


### PR DESCRIPTION
use cases:

1. run on the Galaxy machine and trigger caching of (singularity) containers (I'm using this since a long time on my machine: https://github.com/bernt-matthias/ufz-galaxy-scripts/blob/main/container/install_container.py). We could change this to be able to run also from remote machines (currently I'm checking if the path exists - since the resolvers also give a path if the container is not yet cached).
3. determine a table mapping docker URIs and container image names (paths). this table can then be used on machines that do not have access to CVMFS to download container images.

what the tool does

queries the list of tools from an instance (optionaly filter by regexes on the tool_ids and latest version)

for each tool:

- resolve the container (for cached singularity containers with a configured cache directory this will yield a path)
- if `--install_container` the resolver(s) will be called again with the `install` parameter set to `True` (if the determined path does not exist)
- if `--tabulate N` is used the `N`-th configured resolver is called and the result is printed together with the tool_id and the path that was determined in the 1st step (tab separated). The idea is that the instance configures a singularity container resolver (at index N) without a cache directory defined. This resolver will yield the original container URI (docker://...). If this resolver is defined after the cached / non-cached singularity container resolvers it should never be called in production.