### PR TITLE
Galaxy 26 compatibility: fix test deps + run-data-managers history

### DIFF
--- a/dev-requirements.txt
+++ b/dev-requirements.txt
@@ -4,6 +4,11 @@ coverage
 pytest
 pytest-cov
 galaxy-test-driver
+# Pin galaxy-app to the same release line as the rest of the Galaxy stack.
+# It is only pulled in transitively (via galaxy-test-driver), so pip is free to
+# backtrack it to an older release than galaxy-data/galaxy-util, producing a
+# skewed install whose galaxy.model import fails during test collection.
+galaxy-app>=26
 
 #Building Docs
 sphinx_rtd_theme

--- a/src/ephemeris/run_data_managers.py
+++ b/src/ephemeris/run_data_managers.py
@@ -280,9 +280,10 @@ class DataManagers:
         if not log:
             log = logging.getLogger()
 
-        history_id: str | None = None
-        if history_name is not None:
-            history_id = get_or_create_history(history_name, self.gi)["id"]
+        # Galaxy 26.0 requires a valid history to execute tools, so always run the
+        # data managers in a (default-named) history rather than relying on Galaxy
+        # to supply one implicitly.
+        history_id = get_or_create_history(history_name or "Ephemeris Data Manager History", self.gi)["id"]
 
         def run_jobs(jobs, skipped_jobs):
             job_list = []


### PR DESCRIPTION
> Drafted by Claude (AI assistant) on behalf of @jmchilton.

Galaxy 26.0.0 (released 2026-04-09, after ephemeris's last green CI on galaxy 25.1.2) broke `pytest` on `master` and every open PR in two independent ways. This PR restores green CI by moving ephemeris forward onto Galaxy 26.

## 1. Skewed test-dependency resolution → collection ImportError

`galaxy-app` is only pulled in transitively (via `galaxy-test-driver`), so pip backtracks it to `25.1.2` while `galaxy-data`/`galaxy-util`/`galaxy-tool-util`/`galaxy-test-driver` resolve to `26.0.1`. The test driver imports `galaxy.authnz.custos_authnz`, which imports `CustosAuthnzToken` — removed from `galaxy.model` in 26.x — so collection aborts:

```
ImportError: cannot import name 'CustosAuthnzToken' from 'galaxy.model'
```

**Fix:** pin `galaxy-app>=26` in `dev-requirements.txt` so it stays on the same release line as the rest of the stack.

## 2. `run-data-managers` fails on Galaxy 26 → 3 integration-test failures

Once collection is fixed, `tests/test_run_data_managers.py` surfaces a real incompatibility:

```
bioblend.ConnectionError: 400: "A valid history is required to execute tools." (400007)
```

Galaxy 26.0 no longer executes tools without a history. `run-data-managers` passed `history_id=None` when `--history-name` was unset, relying on Galaxy to supply one implicitly.

**Fix:** always run the data managers in a (default-named) history.

## Verification

- Dep skew reproduced in a clean venv: stock requirements give `galaxy-app==25.1.2` + `galaxy-data==26.0.1` and the import fails; with the pin the stack resolves to `26.0.1` and the full `conftest` import chain imports cleanly.
- `tests/test_run_data_managers.py` — **4 passed** locally (the 3 previously failing + the install test) against Galaxy 26.0.1.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
